### PR TITLE
Fix too many requests being sent in subcommands using Bio.Entrez

### DIFF
--- a/virtool_cli/isolate.py
+++ b/virtool_cli/isolate.py
@@ -301,11 +301,11 @@ def get_cache() -> dict:
 
     :return: A dictionary that maps taxon ids to found accessions
     """
-    if not os.path.isdir(".cli"):
+    try:
+        with open(".cli/accessions.json", "r") as f:
+            return json.load(f)
+    except (NotADirectoryError, FileNotFoundError):
         return {}
-
-    with open(".cli/accessions_cache.json", "r") as f:
-        return json.load(f)
 
 
 def update_cache(existing_cache: dict, results: list) -> dict:
@@ -334,7 +334,7 @@ def write_cache(accessions: dict):
     except FileExistsError:
         pass
 
-    with open(".cli/accessions_cache.json", "w") as f:
+    with open(".cli/accessions.json", "w") as f:
         json.dump(accessions, f, indent=4)
 
 

--- a/virtool_cli/taxid.py
+++ b/virtool_cli/taxid.py
@@ -11,8 +11,6 @@ from virtool_cli.utils import get_otu_paths, NCBI_REQUEST_INTERVAL
 from rich.console import Console
 from rich.progress import BarColumn, Progress, TimeRemainingColumn, TaskID
 
-missed_otus = {"otus": []}
-
 
 async def taxid(src_path: str, force_update: bool):
     """
@@ -82,10 +80,6 @@ async def taxid(src_path: str, force_update: bool):
         update_otu(taxid, otu_paths[name])
 
     console.print(f"\nRetrieved {len(taxids)} taxids for {len(names)} OTUs", style="green")
-    if len(missed_otus["otus"]):
-        console.print(f"OTUs that could not be retrieved have been logged to missed_otus.json", style="green")
-        with open("missed_otus.json", 'w') as f:
-            json.dump(missed_otus, f, indent=4)
 
 
 def fetch_taxid(name: str) -> (str, str):
@@ -106,7 +100,6 @@ def fetch_taxid(name: str) -> (str, str):
         taxid = record["IdList"][0]
     except IndexError:
         taxid = None
-        missed_otus["otus"].append(name)
 
     return taxid
 

--- a/virtool_cli/utils.py
+++ b/virtool_cli/utils.py
@@ -8,7 +8,7 @@ from Bio import Entrez
 Entrez.email = os.environ.get("NCBI_EMAIL")
 Entrez.api_key = os.environ.get("NCBI_API_KEY")
 
-NCBI_REQUEST_INTERVAL = 0.4 if Entrez.email and Entrez.api_key else 0.6
+NCBI_REQUEST_INTERVAL = 0.3 if Entrez.email and Entrez.api_key else 0.6
 
 
 def get_otu_paths(src_path: str) -> list:


### PR DESCRIPTION
- Resolves an issue where the requests do not properly respect the NCBI Entrez rate limit (Closes #19). 

This is caused by the expected behaviour of [aiojobs](https://aiojobs.readthedocs.io/en/stable/api.html#aiojobs.Scheduler.spawn), where jobs are pushed into a queue if they exceed the scheduler's concurrency limit. Once in this queue, jobs can immediately be executed in the scheduler as soon the amount of active jobs is less than the concurrency limit. This leads to scenarios where many jobs can pile up in the queue and then execute all at once, exceeding the Entrez API's rate limit.
