### PR TITLE
Store taxonomy IDs as integers

### DIFF
--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+
+TEST_FILES_PATH = Path(__file__).parent.parent / "tests" / "files"

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,4 +1,3 @@
 from pathlib import Path
 
-
 TEST_FILES_PATH = Path(__file__).parent.parent / "tests" / "files"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,11 +4,10 @@ import arrow
 import pytest
 import subprocess
 
-from pathlib import Path
+from paths import TEST_FILES_PATH
 
-TEST_FILES = Path(__file__).parent.parent / "tests" / "files"
-TEST_PATH = TEST_FILES / "reference.json"
-TEST_WITH_INDENT_PATH = TEST_FILES / "reference_with_indent.json"
+TEST_PATH = TEST_FILES_PATH / "reference.json"
+TEST_WITH_INDENT_PATH = TEST_FILES_PATH/ "reference_with_indent.json"
 
 
 @pytest.fixture()
@@ -21,7 +20,7 @@ def command(output):
     return [
         "virtool",
         "build", "-o", str(output),
-        "-src", TEST_FILES / "src"]
+        "-src", TEST_FILES_PATH / "src"]
 
 
 @pytest.mark.parametrize("version", [None, "v1.0.0", "v0.9.3"])

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,8 +4,11 @@ import arrow
 import pytest
 import subprocess
 
-TEST_PATH = "tests/files/reference.json"
-TEST_WITH_INDENT_PATH = "tests/files/reference_with_indent.json"
+from pathlib import Path
+
+TEST_FILES = Path(__file__).parent.parent / "tests" / "files"
+TEST_PATH = TEST_FILES / "reference.json"
+TEST_WITH_INDENT_PATH = TEST_FILES / "reference_with_indent.json"
 
 
 @pytest.fixture()
@@ -16,9 +19,9 @@ def output(tmpdir):
 @pytest.fixture()
 def command(output):
     return [
-        "python", "virtool_cli/run.py",
+        "virtool",
         "build", "-o", str(output),
-        "-src", "tests/files/src"]
+        "-src", TEST_FILES / "src"]
 
 
 @pytest.mark.parametrize("version", [None, "v1.0.0", "v0.9.3"])

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,7 +7,7 @@ import subprocess
 from paths import TEST_FILES_PATH
 
 TEST_PATH = TEST_FILES_PATH / "reference.json"
-TEST_WITH_INDENT_PATH = TEST_FILES_PATH/ "reference_with_indent.json"
+TEST_WITH_INDENT_PATH = TEST_FILES_PATH / "reference_with_indent.json"
 
 
 @pytest.fixture()

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -4,7 +4,6 @@ import filecmp
 
 from paths import TEST_FILES_PATH
 
-
 TEST_PATH = TEST_FILES_PATH / "reference.json"
 TEST_WITH_INDENT_PATH = TEST_FILES_PATH / "reference_with_indent.json"
 TEST_DIRECTORY_PATH = TEST_FILES_PATH / "src"

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -2,9 +2,10 @@ import pytest
 import subprocess
 import filecmp
 
-TEST_PATH = "tests/files/reference.json"
-TEST_WITH_INDENT_PATH = "tests/files/reference_with_indent.json"
-TEST_DIRECTORY_PATH = "tests/files/src"
+from test_build import TEST_FILES
+TEST_PATH = TEST_FILES / "reference.json"
+TEST_WITH_INDENT_PATH = TEST_FILES / "reference_with_indent.json"
+TEST_DIRECTORY_PATH = TEST_FILES / "src"
 
 
 @pytest.fixture()
@@ -14,10 +15,7 @@ def output(tmpdir):
 
 @pytest.fixture()
 def command(output):
-    return [
-        "python", "virtool_cli/run.py",
-        "divide", "-o", str(output),
-        "-src"]
+    return ["virtool", "divide", "-o", str(output), "-src"]
 
 
 @pytest.mark.parametrize("src", [TEST_PATH, TEST_WITH_INDENT_PATH])

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -2,10 +2,12 @@ import pytest
 import subprocess
 import filecmp
 
-from test_build import TEST_FILES
-TEST_PATH = TEST_FILES / "reference.json"
-TEST_WITH_INDENT_PATH = TEST_FILES / "reference_with_indent.json"
-TEST_DIRECTORY_PATH = TEST_FILES / "src"
+from paths import TEST_FILES_PATH
+
+
+TEST_PATH = TEST_FILES_PATH / "reference.json"
+TEST_WITH_INDENT_PATH = TEST_FILES_PATH / "reference_with_indent.json"
+TEST_DIRECTORY_PATH = TEST_FILES_PATH / "src"
 
 
 @pytest.fixture()

--- a/tests/test_taxid.py
+++ b/tests/test_taxid.py
@@ -3,7 +3,10 @@ import os
 import json
 import subprocess
 
-TEST_PATH = "tests/files/src_a"
+
+TEST_PATH = "files/src_a"
+REF_TEST_PATH = "tests/files/reference.json"
+REF_INDENT_TEST_PATH = "tests/files/reference_with_indent.json"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -27,3 +30,6 @@ def test_taxid(path, command):
             assert otu["taxid"] is None
         else:
             assert otu["taxid"] is not None
+            assert type(otu["taxid"]) == int
+
+

--- a/tests/test_taxid.py
+++ b/tests/test_taxid.py
@@ -3,10 +3,9 @@ import os
 import json
 import subprocess
 
+from test_build import TEST_FILES
 
-TEST_PATH = "files/src_a"
-REF_TEST_PATH = "tests/files/reference.json"
-REF_INDENT_TEST_PATH = "tests/files/reference_with_indent.json"
+TEST_PATH = TEST_FILES / "src_a"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_taxid.py
+++ b/tests/test_taxid.py
@@ -29,6 +29,6 @@ def test_taxid(path, command):
             assert otu["taxid"] is None
         else:
             assert otu["taxid"] is not None
-            assert type(otu["taxid"]) == int
+            assert isinstance(otu["taxid"], int)
 
 

--- a/tests/test_taxid.py
+++ b/tests/test_taxid.py
@@ -3,9 +3,9 @@ import os
 import json
 import subprocess
 
-from test_build import TEST_FILES
+from paths import TEST_FILES_PATH
 
-TEST_PATH = TEST_FILES / "src_a"
+TEST_PATH = TEST_FILES_PATH / "src_a"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/virtool_cli/taxid.py
+++ b/virtool_cli/taxid.py
@@ -71,7 +71,7 @@ async def taxid(src_path: pathlib.Path, force_update: bool):
     console.print(f"\nRetrieved {len(taxids)} taxids for {len(names)} OTUs", style="green")
 
 
-def fetch_taxid(name: str) -> str:
+def fetch_taxid(name: str) -> int:
     """
     Searches the NCBI taxonomy database for a given OTU name and fetches and returns
     its taxon id. If a taxon id was not found the function should return None.
@@ -83,7 +83,7 @@ def fetch_taxid(name: str) -> str:
     record = Entrez.read(handle)
 
     try:
-        taxid = record["IdList"][0]
+        taxid = int(record["IdList"][0])
     except IndexError:
         taxid = None
 
@@ -106,7 +106,7 @@ async def fetch_taxid_call(name: str, q: asyncio.queues.Queue, console: Console)
     await q.put((name, taxid))
 
 
-async def log_results(name: str, taxid: str, console: Console):
+async def log_results(name: str, taxid: int, console: Console):
     """
     Logs results of the taxid fetch from the NCBI taxonomy database
 
@@ -124,7 +124,7 @@ async def log_results(name: str, taxid: str, console: Console):
     console.print()
 
 
-def update_otu(taxid: str, path: pathlib.Path):
+def update_otu(taxid: int, path: pathlib.Path):
     """
     Updates a otu.json's taxid key with either a taxon id or None
     depending on whether an id was able to be retrieved.
@@ -134,7 +134,7 @@ def update_otu(taxid: str, path: pathlib.Path):
     """
     with open(path / "otu.json", 'r+') as f:
         otu = json.load(f)
-        otu["taxid"] = int(taxid) if taxid else taxid
+        otu["taxid"] = taxid if taxid else taxid
         f.seek(0)
         json.dump(otu, f, indent=4)
 

--- a/virtool_cli/utils.py
+++ b/virtool_cli/utils.py
@@ -64,6 +64,7 @@ def create_otu_path(otu_name: str, reference_path: pathlib.Path = None, first_le
 
     return otu_name.replace(" ", "_").replace("/", "_").lower()
 
+
 async def get_isolates(path: pathlib.Path) -> dict:
     """
     Returns a mapping to every isolate and their folder name.


### PR DESCRIPTION
* Update `taxid.py` to pass and return taxids as integers
* Update tests to use pathlib objects
* Update virtool commands in tests to use click `build`, `taxid`, and `divide` commands