### PR TITLE
Annotation Changes for HMM Generation

### DIFF
--- a/tests/test_annotation_vfam.py
+++ b/tests/test_annotation_vfam.py
@@ -14,17 +14,17 @@ def test_get_taxonomy(input_path):
     with input_path.open("r") as handle:
         json_decode = json.load(handle)
         for annotation in json_decode:
-            assert annotation["count"] == len(annotation["entries"])
             family_count = 0
             if "families" in annotation:
                 for i in annotation["families"]:
                     family_count += annotation["families"][i]
-                assert family_count <= len(annotation["entries"])
-                assert annotation["count"] >= family_count
+                assert family_count == len(annotation["entries"])
+                assert annotation["count"] == family_count
 
             genus_count = 0
             if "genera" in annotation:
                 for i in annotation["genera"]:
                     genus_count += annotation["genera"][i]
                 assert genus_count == family_count
+
 

--- a/tests/test_curate_vfam.py
+++ b/tests/test_curate_vfam.py
@@ -48,11 +48,9 @@ def test_remove_phages(input_paths, input_dir):
     GENERIC_INPUT,
     LARGE_INPUT
 ])
-def test_curated_file(input_dir, group_records, output):
+def test_curated_file(input_dir, curated_recs):
     """Assert all sequences are longer than min_length, no record descriptions contain "phage"."""
-    no_dupes = write_curated_recs(group_records, output, 1)
-
-    with Path(no_dupes) as handle:
+    with Path(curated_recs) as handle:
         for record in SeqIO.parse(handle, "fasta"):
             assert len(record.seq) > 1
 
@@ -62,10 +60,9 @@ def test_curated_file(input_dir, group_records, output):
     (GENERIC_INPUT, FILTERED_GENERIC),
     (LARGE_INPUT, FILTERED_LARGE)
 ])
-def test_remove_dupes(input_dir, input_paths, filtered_file, output):
+def test_remove_dupes(filtered_file, curated_recs):
     """Test that remove_dupes step of program produces desired output to match filtered og vfam file."""
-    records = group_input_paths(input_paths, False)
-    result = write_curated_recs(records, output, 1)
+    result = curated_recs
     expected = Path(filtered_file)
 
     assert filecmp.cmp(result, expected, shallow=True)

--- a/tests/vfam_intermediates/Large/master.json
+++ b/tests/vfam_intermediates/Large/master.json
@@ -2,196 +2,4709 @@
     {
         "cluster": "1",
         "names": [
-            "polyprotein",
-            "hypothetical protein",
-            "flavivirus polyprotein"
+            "polymerase",
+            "L",
+            "RNA-dependent RNA polymerase"
         ],
         "entries": [
             {
-                "accession": "YP_009175071.1",
-                "name": "polyprotein",
-                "organism": "Macrosiphum euphorbiae virus 1"
+                "accession": "YP_009176971.1",
+                "name": "L",
+                "organism": "Inhangapi virus"
             },
             {
-                "accession": "YP_009177201.1",
-                "name": "gamma protein",
+                "accession": "YP_009176977.1",
+                "name": "RNA-dependent RNA polymerase",
+                "organism": "Datura yellow vein nucleorhabdovirus"
+            },
+            {
+                "accession": "YP_009176985.1",
+                "name": "RNA-dependent RNA polymerase",
+                "organism": "Walkabout Creek virus"
+            },
+            {
+                "accession": "YP_009177014.1",
+                "name": "L",
+                "organism": "Kumasi rhabdovirus"
+            },
+            {
+                "accession": "YP_009177203.1",
+                "name": "polymerase",
                 "organism": "Koolpinyah virus"
             },
             {
-                "accession": "YP_009177224.1",
-                "name": "3 protein",
+                "accession": "YP_009177215.1",
+                "name": "polymerase",
+                "organism": "Yata virus"
+            },
+            {
+                "accession": "YP_009177231.1",
+                "name": "L protein",
                 "organism": "Barley yellow striate mosaic cytorhabdovirus"
             },
             {
-                "accession": "YP_009179217.1",
-                "name": "polyprotein",
-                "organism": "Tacheng tick virus 8"
+                "accession": "YP_009177247.1",
+                "name": "polymerase",
+                "organism": "Adelaide River virus"
             },
             {
-                "accession": "YP_009179219.1",
-                "name": "polyprotein",
-                "organism": "Shayang spider virus 4"
+                "accession": "YP_009177651.1",
+                "name": "L polymerase protein",
+                "organism": "Cocal virus"
             },
             {
-                "accession": "YP_009179220.1",
-                "name": "polyprotein",
-                "organism": "Xingshan cricket virus"
+                "accession": "YP_009204560.1",
+                "name": "L protein",
+                "organism": "Fox fecal rhabdovirus"
+            }
+        ],
+        "count": 10.0,
+        "alen": 2454,
+        "length": 2123,
+        "eff_nseq": 1.79,
+        "mean_entropy": 0.59,
+        "total_entropy": 5.9,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Rhabdoviridae": 3,
+            "Sunrhavirus": 1,
+            "Alpharhabdovirinae": 5,
+            "Betarhabdovirinae": 1
+        },
+        "genera": {
+            "unclassified Rhabdoviridae": 2,
+            "Walkabout sunrhavirus": 1,
+            "Ephemerovirus": 3,
+            "Ledantevirus": 1,
+            "Cytorhabdovirus": 1,
+            "Nucleorhabdovirus": 1,
+            "Vesiculovirus": 1
+        }
+    },
+    {
+        "cluster": "100",
+        "names": [
+            "odv-e18",
+            "ODV-E18"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182207.1",
+                "name": "ODV-E18",
+                "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009179221.1",
-                "name": "polyprotein",
-                "organism": "Bole tick virus 4"
+                "accession": "YP_009186710.1",
+                "name": "odv-e18",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009179222.1",
-                "name": "polyprotein",
-                "organism": "Xinzhou spider virus 2"
+                "accession": "YP_009229930.1",
+                "name": "odv-e18",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 98,
+        "length": 87,
+        "eff_nseq": 0.72,
+        "mean_entropy": 0.652,
+        "total_entropy": 1.96,
+        "mean_positional_relative_entropy": 0.58,
+        "kullback_leibler_divergence": 0.05,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "101",
+        "names": [
+            "lef-4",
+            "late expression factor 4"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182284.1",
+                "name": "late expression factor 4",
+                "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009179223.1",
-                "name": "polyprotein",
-                "organism": "Shuangao lacewing virus 2"
+                "accession": "YP_009186765.1",
+                "name": "lef-4",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009179224.1",
-                "name": "polyprotein",
-                "organism": "Gamboa mosquito virus"
-            },
+                "accession": "YP_009229995.1",
+                "name": "lef-4",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 518,
+        "length": 450,
+        "eff_nseq": 0.64,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "102",
+        "names": [
+            "hypothetical protein",
+            "ac75"
+        ],
+        "entries": [
             {
-                "accession": "YP_009179225.1",
-                "name": "polyprotein",
-                "organism": "Shayang fly virus 4"
-            },
-            {
-                "accession": "YP_009179226.1",
-                "name": "polyprotein",
-                "organism": "Beihai barnacle viurs 1"
-            },
-            {
-                "accession": "YP_009179227.1",
-                "name": "flavivirus polyprotein",
-                "organism": "Wenling shark virus"
-            },
-            {
-                "accession": "YP_009182226.1",
+                "accession": "YP_009182293.1",
                 "name": "hypothetical protein",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009186718.1",
-                "name": "39k",
+                "accession": "YP_009186755.1",
+                "name": "ac75",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009186726.1",
-                "name": "djbp",
+                "accession": "YP_009230027.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 163,
+        "length": 151,
+        "eff_nseq": 0.74,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.06,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "105",
+        "names": [
+            "F",
+            "efp"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182223.1",
+                "name": "F",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229964.1",
+                "name": "efp",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 602,
+        "length": 602,
+        "eff_nseq": 0.53,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "106",
+        "names": [
+            "structural protein",
+            "capsid triplex subunit 2",
+            "capsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186689.1",
+                "name": "structural protein",
+                "organism": "Pan troglodytes verus polyomavirus 8"
+            },
+            {
+                "accession": "YP_009227251.1",
+                "name": "capsid triplex subunit 2",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230149.1",
+                "name": "capsid protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 380,
+        "length": 318,
+        "eff_nseq": 0.83,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Polyomaviridae": 1,
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Betapolyomavirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "108",
+        "names": [
+            "odv-e25",
+            "ODV-E25"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182281.1",
+                "name": "ODV-E25",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186769.1",
+                "name": "odv-e25",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
+            {
+                "accession": "YP_009229992.1",
+                "name": "odv-e25",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 229,
+        "length": 214,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "109",
+        "names": [
+            "ODV-E27",
+            "odv-ec27",
+            "odv-e27"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182286.1",
+                "name": "ODV-E27",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186711.1",
+                "name": "odv-ec27",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229997.1",
+                "name": "odv-e27",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 313,
+        "length": 292,
+        "eff_nseq": 0.74,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "11",
+        "names": [
+            "hypothetical protein",
+            "movement protein",
+            "GP3 protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_008999614.1",
+                "name": "movement protein",
+                "organism": "Eggplant mottled crinkle virus"
+            },
+            {
+                "accession": "YP_009182224.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009222001.1",
+                "name": "GP3 protein",
+                "organism": "Kafue kinda chacma baboon virus"
+            },
+            {
+                "accession": "YP_009229917.1",
+                "name": "hypothetical protein",
+                "organism": "Blackberry virus F"
+            }
+        ],
+        "count": 4.0,
+        "alen": 196,
+        "length": 168,
+        "eff_nseq": 1.88,
+        "mean_entropy": 0.589,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 1,
+            "Procedovirinae": 1,
+            "Kaftartevirus": 1,
+            "Caulimoviridae": 1
+        },
+        "genera": {
+            "Betabaculovirus": 1,
+            "Tombusvirus": 1,
+            "Thetaarterivirus kafuba": 1,
+            "Badnavirus": 1
+        }
+    },
+    {
+        "cluster": "110",
+        "names": [
+            "pif-2",
+            "per os infectivity factor 2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182240.1",
+                "name": "per os infectivity factor 2",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186804.1",
+                "name": "pif-2",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229967.1",
+                "name": "pif-2",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 388,
+        "length": 376,
+        "eff_nseq": 0.52,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "111",
+        "names": [
+            "tegument protein",
+            "tegument protein UL16",
+            "membrane protein UL43"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227249.1",
+                "name": "tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230145.1",
+                "name": "tegument protein UL16",
+                "organism": "Leporid alphaherpesvirus 4"
+            },
+            {
+                "accession": "YP_009230175.1",
+                "name": "membrane protein UL43",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 455,
+        "length": 364,
+        "eff_nseq": 0.84,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Simplexvirus": 3
+        }
+    },
+    {
+        "cluster": "114",
+        "names": [
+            "hypothetical protein",
+            "odv-e66"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182230.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229959.1",
+                "name": "odv-e66",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 133,
+        "length": 133,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "115",
+        "names": [
+            "beta protein",
+            "DNA packaging protein",
+            "DNA packaging protein UL33"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177246.1",
+                "name": "beta protein",
+                "organism": "Adelaide River virus"
+            },
+            {
+                "accession": "YP_009227266.1",
+                "name": "DNA packaging protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230163.1",
+                "name": "DNA packaging protein UL33",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 181,
+        "length": 134,
+        "eff_nseq": 0.82,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.49,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alpharhabdovirinae": 1,
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Ephemerovirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "116",
+        "names": [
+            "lef-9",
+            "late expression factor 9"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182302.1",
+                "name": "late expression factor 9",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186740.1",
+                "name": "lef-9",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230019.1",
+                "name": "lef-9",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 511,
+        "length": 498,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "117",
+        "names": [
+            "protein kinase-1",
+            "pk-1",
+            "p78/83"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182201.1",
+                "name": "protein kinase-1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186694.1",
+                "name": "pk-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229922.1",
+                "name": "p78/83",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 275,
+        "length": 271,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "118",
+        "names": [
+            "ubiquitin",
+            "ubiquitin-like protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182246.1",
+                "name": "ubiquitin-like protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186717.1",
+                "name": "ubiquitin",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229952.1",
+                "name": "ubiquitin",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 118,
+        "length": 95,
+        "eff_nseq": 0.48,
+        "mean_entropy": 0.602,
+        "total_entropy": 1.81,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "119",
+        "names": [
+            "odv-ec43",
+            "ODV-EC43"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182247.1",
+                "name": "ODV-EC43",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186780.1",
+                "name": "odv-ec43",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229951.1",
+                "name": "odv-ec43",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 396,
+        "length": 348,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "120",
+        "names": [
+            "hypothetical protein",
+            "polyhedron envelope protein 1",
+            "2A"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182212.1",
+                "name": "polyhedron envelope protein 1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009182218.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009220470.1",
+                "name": "2A",
+                "organism": "Tupaia hepatovirus A"
+            },
+            {
+                "accession": "YP_009229934.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 229,
+        "length": 189,
+        "eff_nseq": 1.4,
+        "mean_entropy": 0.589,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3,
+            "Hepatovirus": 1
+        },
+        "genera": {
+            "Betabaculovirus": 3,
+            "unclassified Hepatovirus": 1
+        }
+    },
+    {
+        "cluster": "123",
+        "names": [
+            "immediate early protein ICP0",
+            "ubiquitin E3 ligase ICP0"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227214.1",
+                "name": "ubiquitin E3 ligase ICP0",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230128.1",
+                "name": "immediate early protein ICP0",
+                "organism": "Leporid alphaherpesvirus 4"
+            },
+            {
+                "accession": "YP_009230192.1",
+                "name": "immediate early protein ICP0",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 616,
+        "length": 585,
+        "eff_nseq": 0.68,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.06,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Simplexvirus": 3
+        }
+    },
+    {
+        "cluster": "124",
+        "names": [
+            "hypothetical protein",
+            "ac76"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182292.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186756.1",
+                "name": "ac76",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230010.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 85,
+        "length": 84,
+        "eff_nseq": 0.71,
+        "mean_entropy": 0.676,
+        "total_entropy": 2.03,
+        "mean_positional_relative_entropy": 0.61,
+        "kullback_leibler_divergence": 0.06,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "128",
+        "names": [
+            "DNA replication origin-binding helicase",
+            "DNA replication origin-binding helicase UL9"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227242.1",
+                "name": "DNA replication origin-binding helicase",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230139.1",
+                "name": "DNA replication origin-binding helicase UL9",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 875,
+        "length": 875,
+        "eff_nseq": 0.47,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "13",
+        "names": [
+            "G",
+            "glycoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177013.1",
+                "name": "G",
+                "organism": "Kumasi rhabdovirus"
+            },
+            {
+                "accession": "YP_009177208.1",
+                "name": "glycoprotein",
+                "organism": "Yata virus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 641,
+        "length": 641,
+        "eff_nseq": 0.63,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alpharhabdovirinae": 2
+        },
+        "genera": {
+            "Ledantevirus": 1,
+            "Ephemerovirus": 1
+        }
+    },
+    {
+        "cluster": "130",
+        "names": [
+            "175 kDa protein",
+            "174 kDa protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182154.1",
+                "name": "174 kDa protein",
+                "organism": "Penicillium aurantiogriseum fusarivirus 1"
+            },
+            {
+                "accession": "YP_009182158.1",
+                "name": "175 kDa protein",
+                "organism": "Pleospora typhicola fusarivirus 1"
+            }
+        ],
+        "count": 2.0,
+        "alen": 1599,
+        "length": 1599,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "unclassified ssRNA viruses": 2
+        },
+        "genera": {
+            "Fusariviridae": 2
+        }
+    },
+    {
+        "cluster": "131",
+        "names": [
+            "L1",
+            "L2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177730.1",
+                "name": "L1",
+                "organism": "Trichechus manatus papillomavirus 4"
+            },
+            {
+                "accession": "YP_009182328.1",
+                "name": "L2",
+                "organism": "Rattus norvegicus papillomavirus 3"
+            }
+        ],
+        "count": 2.0,
+        "alen": 507,
+        "length": 507,
+        "eff_nseq": 0.48,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Firstpapillomavirinae": 2
+        },
+        "genera": {
+            "Rhopapillomavirus": 1,
+            "Iotapapillomavirus": 1
+        }
+    },
+    {
+        "cluster": "132",
+        "names": [
+            "non-structural glycoprotein",
+            "non-structural transmembrane glycoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177197.1",
+                "name": "non-structural glycoprotein",
+                "organism": "Koolpinyah virus"
+            },
+            {
+                "accession": "YP_009177243.1",
+                "name": "non-structural transmembrane glycoprotein",
+                "organism": "Adelaide River virus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 637,
+        "length": 637,
+        "eff_nseq": 0.67,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alpharhabdovirinae": 2
+        },
+        "genera": {
+            "Ephemerovirus": 2
+        }
+    },
+    {
+        "cluster": "133",
+        "names": [
+            "capsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182187.1",
+                "name": "capsid protein",
+                "organism": "Red clover powdery mildew-associated totivirus 5"
+            },
+            {
+                "accession": "YP_009182189.1",
+                "name": "capsid protein",
+                "organism": "Red clover powdery mildew-associated totivirus 6"
+            },
+            {
+                "accession": "YP_009182194.1",
+                "name": "capsid protein",
+                "organism": "Red clover powdery mildew-associated totivirus 7"
+            }
+        ],
+        "count": 3.0,
+        "alen": 845,
+        "length": 817,
+        "eff_nseq": 0.82,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Ghabrivirales": 3
+        },
+        "genera": {
+            "Totiviridae": 3
+        }
+    },
+    {
+        "cluster": "135",
+        "names": [
+            "alk-exo",
+            "alkaline exonuclease"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182311.1",
+                "name": "alkaline exonuclease",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186816.1",
+                "name": "alk-exo",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230013.1",
+                "name": "alk-exo",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 470,
+        "length": 407,
+        "eff_nseq": 0.7,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "136",
+        "names": [
+            "ODV-E28",
+            "pif-4"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182279.1",
+                "name": "ODV-E28",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186771.1",
+                "name": "pif-4",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 178,
+        "length": 178,
+        "eff_nseq": 0.54,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 1,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "137",
+        "names": [
+            "hypothetical protein",
+            "ac110"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182245.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186779.1",
+                "name": "ac110",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229953.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 58,
+        "length": 49,
+        "eff_nseq": 1.39,
+        "mean_entropy": 1.129,
+        "total_entropy": 3.39,
+        "mean_positional_relative_entropy": 1.06,
+        "kullback_leibler_divergence": 0.16,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "138",
+        "names": [
+            "BV-E31",
+            "bv-e31",
+            "BV-e31"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182256.1",
+                "name": "BV-E31",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186720.1",
+                "name": "bv-e31",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229970.1",
+                "name": "BV-e31",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 269,
+        "length": 217,
+        "eff_nseq": 0.54,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "14",
+        "names": [
+            "hypothetical protein ORF7",
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009199795.1",
+                "name": "hypothetical protein ORF7",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009230130.1",
+                "name": "hypothetical protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 83,
+        "length": 83,
+        "eff_nseq": 0.88,
+        "mean_entropy": 0.684,
+        "total_entropy": 1.37,
+        "mean_positional_relative_entropy": 0.61,
+        "kullback_leibler_divergence": 0.05,
+        "families": {
+            "Decacovirus": 1,
+            "Alphaherpesvirinae": 1
+        },
+        "genera": {
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Simplexvirus": 1
+        }
+    },
+    {
+        "cluster": "140",
+        "names": [
+            "E1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177727.1",
+                "name": "E1",
+                "organism": "Trichechus manatus papillomavirus 4"
+            },
+            {
+                "accession": "YP_009182326.1",
+                "name": "E1",
+                "organism": "Rattus norvegicus papillomavirus 3"
+            }
+        ],
+        "count": 2.0,
+        "alen": 629,
+        "length": 629,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.586,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Firstpapillomavirinae": 2
+        },
+        "genera": {
+            "Rhopapillomavirus": 1,
+            "Iotapapillomavirus": 1
+        }
+    },
+    {
+        "cluster": "141",
+        "names": [
+            "DNA packaging protein",
+            "DNA packaging protein UL32"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227265.1",
+                "name": "DNA packaging protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230162.1",
+                "name": "DNA packaging protein UL32",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 639,
+        "length": 639,
+        "eff_nseq": 0.49,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "143",
+        "names": [
+            "hypothetical protein",
+            "ac52"
+        ],
+        "entries": [
             {
                 "accession": "YP_009186728.1",
                 "name": "ac52",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009186778.1",
-                "name": "vp80",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186797.1",
-                "name": "orf106",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009199243.1",
-                "name": "non-structural protein 3a",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199248.1",
-                "name": "non-structural protein 7",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009220466.1",
-                "name": "VP1",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009222000.1",
-                "name": "GP2b protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009227125.1",
+                "accession": "YP_009226562.1",
                 "name": "hypothetical protein",
-                "organism": "Rosellinia necatrix megabirnavirus 2-W8"
+                "organism": "Ctenophore-associated circular virus 1"
             },
             {
-                "accession": "YP_009227282.1",
-                "name": "glycoprotein N",
+                "accession": "YP_009226566.1",
+                "name": "hypothetical protein",
+                "organism": "Ctenophore-associated circular virus 3"
+            }
+        ],
+        "count": 3.0,
+        "alen": 254,
+        "length": 230,
+        "eff_nseq": 0.98,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 1,
+            "unclassified DNA viruses": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "unclassified ssDNA viruses": 2
+        }
+    },
+    {
+        "cluster": "145",
+        "names": [
+            "DNA polymerase"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227263.1",
+                "name": "DNA polymerase",
                 "organism": "Macropodid alphaherpesvirus 1"
             },
             {
-                "accession": "YP_009229977.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
+                "accession": "YP_009230161.1",
+                "name": "DNA polymerase",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 1231,
+        "length": 1231,
+        "eff_nseq": 0.47,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "146",
+        "names": [
+            "helicase primase subunit",
+            "UL52 helicase-primase primase subunit"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227285.1",
+                "name": "helicase primase subunit",
+                "organism": "Macropodid alphaherpesvirus 1"
             },
             {
-                "accession": "YP_009230030.1",
+                "accession": "YP_009230187.1",
+                "name": "UL52 helicase-primase primase subunit",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 1034,
+        "length": 1034,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "148",
+        "names": [
+            "glycoprotein D",
+            "envelope glycoprotein D"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227224.1",
+                "name": "glycoprotein D",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230199.1",
+                "name": "envelope glycoprotein D",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 397,
+        "length": 397,
+        "eff_nseq": 0.52,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "149",
+        "names": [
+            "glycoprotein M",
+            "envelope glycoprotein M UL10"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227243.1",
+                "name": "glycoprotein M",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230140.1",
+                "name": "envelope glycoprotein M UL10",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 451,
+        "length": 451,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "15",
+        "names": [
+            "nucleoprotein",
+            "N",
+            "nucleocapsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009176966.1",
+                "name": "N",
+                "organism": "Inhangapi virus"
+            },
+            {
+                "accession": "YP_009176978.1",
+                "name": "nucleoprotein",
+                "organism": "Walkabout Creek virus"
+            },
+            {
+                "accession": "YP_009177008.1",
+                "name": "N",
+                "organism": "Kumasi rhabdovirus"
+            },
+            {
+                "accession": "YP_009177193.1",
+                "name": "nucleoprotein",
+                "organism": "Koolpinyah virus"
+            },
+            {
+                "accession": "YP_009177205.1",
+                "name": "nucleoprotein",
+                "organism": "Yata virus"
+            },
+            {
+                "accession": "YP_009177239.1",
+                "name": "nucleocapsid protein",
+                "organism": "Adelaide River virus"
+            },
+            {
+                "accession": "YP_009177647.1",
+                "name": "nucleocapsid protein",
+                "organism": "Cocal virus"
+            }
+        ],
+        "count": 7.0,
+        "alen": 445,
+        "length": 425,
+        "eff_nseq": 1.06,
+        "mean_entropy": 0.59,
+        "total_entropy": 4.13,
+        "mean_positional_relative_entropy": 0.54,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Rhabdoviridae": 1,
+            "Sunrhavirus": 1,
+            "Alpharhabdovirinae": 5
+        },
+        "genera": {
+            "unclassified Rhabdoviridae": 1,
+            "Walkabout sunrhavirus": 1,
+            "Ephemerovirus": 3,
+            "Ledantevirus": 1,
+            "Vesiculovirus": 1
+        }
+    },
+    {
+        "cluster": "150",
+        "names": [
+            "NP1",
+            "NP1 protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009215302.1",
+                "name": "NP1",
+                "organism": "Lagomorph bocaparvovirus 1"
+            },
+            {
+                "accession": "YP_009227292.1",
+                "name": "NP1",
+                "organism": "Rat bocavirus"
+            },
+            {
+                "accession": "YP_009229909.1",
+                "name": "NP1 protein",
+                "organism": "Bat bocavirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 216,
+        "length": 196,
+        "eff_nseq": 0.67,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Parvovirinae": 1,
+            "Bocaparvovirus": 2
+        },
+        "genera": {
+            "Bocaparvovirus": 1,
+            "Rodent bocaparvovirus 1": 1,
+            "unclassified Bocaparvovirus": 1
+        }
+    },
+    {
+        "cluster": "151",
+        "names": [
+            "phosphoprotein",
+            "P"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009176967.1",
+                "name": "P",
+                "organism": "Inhangapi virus"
+            },
+            {
+                "accession": "YP_009177194.1",
+                "name": "phosphoprotein",
+                "organism": "Koolpinyah virus"
+            },
+            {
+                "accession": "YP_009177206.1",
+                "name": "phosphoprotein",
+                "organism": "Yata virus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 323,
+        "length": 273,
+        "eff_nseq": 0.93,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Rhabdoviridae": 1,
+            "Alpharhabdovirinae": 2
+        },
+        "genera": {
+            "unclassified Rhabdoviridae": 1,
+            "Ephemerovirus": 2
+        }
+    },
+    {
+        "cluster": "152",
+        "names": [
+            "lef-8",
+            "late expression factor 8"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182317.1",
+                "name": "late expression factor 8",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186724.1",
+                "name": "lef-8",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230028.1",
+                "name": "lef-8",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 933,
+        "length": 854,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "153",
+        "names": [
+            "deoxyuridine triphosphatase"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227283.1",
+                "name": "deoxyuridine triphosphatase",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230185.1",
+                "name": "deoxyuridine triphosphatase",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 377,
+        "length": 377,
+        "eff_nseq": 0.6,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "155",
+        "names": [
+            "p49",
+            "P49"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182208.1",
+                "name": "P49",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186709.1",
+                "name": "p49",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229931.1",
+                "name": "p49",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 508,
+        "length": 464,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.78,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "156",
+        "names": [
+            "transactivating tegument protein VP16",
+            "UL48 transactivating tegument protein VP16"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227280.1",
+                "name": "transactivating tegument protein VP16",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230181.1",
+                "name": "UL48 transactivating tegument protein VP16",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 554,
+        "length": 554,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "157",
+        "names": [
+            "nuclear phosphoprotein",
+            "nuclear egress lamina protein",
+            "nonstructural protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207092.1",
+                "name": "nuclear phosphoprotein",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009227129.1",
+                "name": "nonstructural protein",
+                "organism": "Adana virus"
+            },
+            {
+                "accession": "YP_009227264.1",
+                "name": "nuclear egress lamina protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            }
+        ],
+        "count": 3.0,
+        "alen": 342,
+        "length": 302,
+        "eff_nseq": 1.02,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2,
+            "Phlebovirus": 1
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 1,
+            "Adana phlebovirus": 1
+        }
+    },
+    {
+        "cluster": "158",
+        "names": [
+            "vlf-1",
+            "very late factor 1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182291.1",
+                "name": "very late factor 1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186757.1",
+                "name": "vlf-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230009.1",
+                "name": "vlf-1",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 400,
+        "length": 377,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "159",
+        "names": [
+            "late expression factor 1",
+            "lef-1",
+            "pif-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182260.1",
+                "name": "late expression factor 1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186812.1",
+                "name": "lef-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229973.1",
+                "name": "pif-1",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 271,
+        "length": 236,
+        "eff_nseq": 0.61,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "16",
+        "names": [
+            "beta protein",
+            "hypothetical protein",
+            "GP4 protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177200.1",
+                "name": "beta protein",
+                "organism": "Koolpinyah virus"
+            },
+            {
+                "accession": "YP_009222002.1",
+                "name": "GP4 protein",
+                "organism": "Kafue kinda chacma baboon virus"
+            },
+            {
+                "accession": "YP_009227289.1",
+                "name": "hypothetical protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            }
+        ],
+        "count": 3.0,
+        "alen": 220,
+        "length": 184,
+        "eff_nseq": 1.22,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alpharhabdovirinae": 1,
+            "Alphaherpesvirinae": 1,
+            "Kaftartevirus": 1
+        },
+        "genera": {
+            "Ephemerovirus": 1,
+            "Simplexvirus": 1,
+            "Thetaarterivirus kafuba": 1
+        }
+    },
+    {
+        "cluster": "160",
+        "names": [
+            "38K",
+            "38k",
+            "lef-5"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182276.1",
+                "name": "38K",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186772.1",
+                "name": "38k",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229989.1",
+                "name": "lef-5",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 335,
+        "length": 310,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.78,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "161",
+        "names": [
+            "thymidine kinase",
+            "thymidine kinase, partial"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207083.1",
+                "name": "thymidine kinase, partial",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009227256.1",
+                "name": "thymidine kinase",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230154.1",
+                "name": "thymidine kinase",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 376,
+        "length": 330,
+        "eff_nseq": 0.79,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "162",
+        "names": [
+            "P40",
+            "p40",
+            "p40/c42"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182273.1",
+                "name": "P40",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186775.1",
+                "name": "p40",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229986.1",
+                "name": "p40/c42",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 403,
+        "length": 389,
+        "eff_nseq": 0.8,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "163",
+        "names": [
+            "hypothetical protein",
+            "ac81"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182220.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186760.1",
+                "name": "ac81",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230006.1",
                 "name": "hypothetical protein",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 27.0,
-        "alen": 10757,
-        "length": 4387,
-        "eff_nseq": 14.06,
-        "mean_entropy": 0.59,
-        "total_entropy": 15.93,
-        "mean_positional_relative_entropy": 0.44,
-        "kullback_leibler_divergence": 0.02,
+        "count": 3.0,
+        "alen": 238,
+        "length": 203,
+        "eff_nseq": 0.53,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
         "families": {
-            "unclassified ssRNA viruses": 9,
-            "Hepacivirus": 1,
-            "Amarillovirales": 1,
-            "Alpharhabdovirinae": 1,
-            "Betarhabdovirinae": 1,
-            "Baculoviridae": 8,
-            "Hepatovirus": 1,
-            "Alphacoronavirus": 2,
-            "Alphaherpesvirinae": 1,
-            "Kaftartevirus": 1,
-            "Megabirnavirus": 1
+            "Baculoviridae": 3
         },
         "genera": {
-            "unclassified ssRNA positive-strand viruses": 9,
-            "unclassified Hepacivirus": 1,
-            "Flaviviridae": 1,
-            "Ephemerovirus": 1,
-            "Cytorhabdovirus": 1,
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 5,
-            "unclassified Hepatovirus": 1,
-            "Tegacovirus": 2,
-            "Simplexvirus": 1,
-            "Thetaarterivirus kafuba": 1,
-            "unclassified Megabirnavirus": 1
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
         }
     },
     {
-        "cluster": "10",
+        "cluster": "164",
         "names": [
-            "glycoprotein",
-            "putative glycoprotein",
-            "alpha1 protein"
+            "endonuclease",
+            "hypothetical protein"
         ],
         "entries": [
             {
-                "accession": "YP_009177198.1",
-                "name": "alpha1 protein",
-                "organism": "Koolpinyah virus"
+                "accession": "YP_009186783.1",
+                "name": "endonuclease",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
+            {
+                "accession": "YP_009230024.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 126,
+        "length": 126,
+        "eff_nseq": 0.6,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "Betabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "165",
+        "names": [
+            "granulin",
+            "polyhedrin"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182199.1",
+                "name": "granulin",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186692.1",
+                "name": "polyhedrin",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229920.1",
+                "name": "granulin",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 249,
+        "length": 248,
+        "eff_nseq": 0.48,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "166",
+        "names": [
+            "pif-3",
+            "per os infectivity factor 3"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182228.1",
+                "name": "per os infectivity factor 3",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186791.1",
+                "name": "pif-3",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229961.1",
+                "name": "pif-3",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 208,
+        "length": 196,
+        "eff_nseq": 0.58,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "167",
+        "names": [
+            "late expression factor 5",
+            "lef-5",
+            "38k"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182275.1",
+                "name": "late expression factor 5",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186773.1",
+                "name": "lef-5",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229988.1",
+                "name": "38k",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 291,
+        "length": 250,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "168",
+        "names": [
+            "hypothetical protein",
+            "ac106"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182244.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186788.1",
+                "name": "ac106",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229954.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 241,
+        "length": 226,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "169",
+        "names": [
+            "hypothetical protein",
+            "pif-6",
+            "lef-3"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182298.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186751.1",
+                "name": "pif-6",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230022.1",
+                "name": "lef-3",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 139,
+        "length": 128,
+        "eff_nseq": 0.63,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "17",
+        "names": [
+            "coat protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009224932.1",
+                "name": "coat protein",
+                "organism": "Elderberry carlavirus A"
+            },
+            {
+                "accession": "YP_009224938.1",
+                "name": "coat protein",
+                "organism": "Elderberry carlavirus B"
+            },
+            {
+                "accession": "YP_009224944.1",
+                "name": "coat protein",
+                "organism": "Elderberry carlavirus C"
+            },
+            {
+                "accession": "YP_009224950.1",
+                "name": "coat protein",
+                "organism": "Elderberry carlavirus D"
+            },
+            {
+                "accession": "YP_009224956.1",
+                "name": "coat protein",
+                "organism": "Elderberry carlavirus E"
+            }
+        ],
+        "count": 5.0,
+        "alen": 320,
+        "length": 298,
+        "eff_nseq": 0.6,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.95,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Quinvirinae": 3,
+            "Carlavirus": 2
+        },
+        "genera": {
+            "Carlavirus": 3,
+            "unclassified Carlavirus": 2
+        }
+    },
+    {
+        "cluster": "170",
+        "names": [
+            "pif-5",
+            "ODV-E56, per os infectivity factor 6"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182210.1",
+                "name": "ODV-E56, per os infectivity factor 6",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186697.1",
+                "name": "pif-5",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229932.1",
+                "name": "pif-5",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 393,
+        "length": 364,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "172",
+        "names": [
+            "pre-coat protein",
+            "AV2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177709.1",
+                "name": "pre-coat protein",
+                "organism": "Andrographis yellow vein leaf curl virus"
+            },
+            {
+                "accession": "YP_009216259.1",
+                "name": "pre-coat protein",
+                "organism": "Okra leaf curl Oman virus"
+            },
+            {
+                "accession": "YP_009216582.1",
+                "name": "AV2",
+                "organism": "Pepper yellow leaf curl Thailand virus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 122,
+        "length": 122,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Geminiviridae": 3
+        },
+        "genera": {
+            "Begomovirus": 3
+        }
+    },
+    {
+        "cluster": "173",
+        "names": [
+            "vp1054",
+            "VP1054"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182322.1",
+                "name": "VP1054",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186732.1",
+                "name": "vp1054",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230034.1",
+                "name": "vp1054",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 399,
+        "length": 332,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "174",
+        "names": [
+            "hypothetical protein",
+            "ep23",
+            "ie-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182205.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186713.1",
+                "name": "ep23",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229926.1",
+                "name": "ie-1",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 215,
+        "length": 194,
+        "eff_nseq": 0.8,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "175",
+        "names": [
+            "per os infectivity factor 1",
+            "pif-1",
+            "lef-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182261.1",
+                "name": "per os infectivity factor 1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186820.1",
+                "name": "pif-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229974.1",
+                "name": "lef-1",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 573,
+        "length": 536,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "176",
+        "names": [
+            "envelope protein",
+            "integral membrane protein UL20"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227253.1",
+                "name": "envelope protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230151.1",
+                "name": "integral membrane protein UL20",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 223,
+        "length": 223,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "177",
+        "names": [
+            "acetyltransferase-like protein",
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182253.1",
+                "name": "acetyltransferase-like protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229944.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 199,
+        "length": 199,
+        "eff_nseq": 0.48,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "179",
+        "names": [
+            "p18",
+            "P18"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182282.1",
+                "name": "P18",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186768.1",
+                "name": "p18",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229993.1",
+                "name": "p18",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 168,
+        "length": 160,
+        "eff_nseq": 0.73,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.05,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "18",
+        "names": [
+            "coat protein",
+            "AV1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009175075.1",
+                "name": "coat protein",
+                "organism": "Melochia mosaic virus"
+            },
+            {
+                "accession": "YP_009175082.1",
+                "name": "coat protein",
+                "organism": "Melochia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009177710.1",
+                "name": "coat protein",
+                "organism": "Andrographis yellow vein leaf curl virus"
+            },
+            {
+                "accession": "YP_009216260.1",
+                "name": "coat protein",
+                "organism": "Okra leaf curl Oman virus"
+            },
+            {
+                "accession": "YP_009216583.1",
+                "name": "AV1",
+                "organism": "Pepper yellow leaf curl Thailand virus"
+            },
+            {
+                "accession": "YP_009226414.1",
+                "name": "coat protein",
+                "organism": "Pavonia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009226624.1",
+                "name": "coat protein",
+                "organism": "Turnip leaf roll virus"
+            }
+        ],
+        "count": 7.0,
+        "alen": 294,
+        "length": 257,
+        "eff_nseq": 0.83,
+        "mean_entropy": 0.592,
+        "total_entropy": 4.14,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Geminiviridae": 7
+        },
+        "genera": {
+            "Begomovirus": 6,
+            "Turncurtovirus": 1
+        }
+    },
+    {
+        "cluster": "180",
+        "names": [
+            "hypothetical protein",
+            "ac53"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182318.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186729.1",
+                "name": "ac53",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230031.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 159,
+        "length": 134,
+        "eff_nseq": 0.69,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "181",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182320.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230033.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 65,
+        "length": 65,
+        "eff_nseq": 0.87,
+        "mean_entropy": 0.863,
+        "total_entropy": 1.73,
+        "mean_positional_relative_entropy": 0.81,
+        "kullback_leibler_divergence": 0.1,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "182",
+        "names": [
+            "DNA polymerase processivity subunit",
+            "DNA polymerase processivity factor"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227275.1",
+                "name": "DNA polymerase processivity subunit",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230174.1",
+                "name": "DNA polymerase processivity factor",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 496,
+        "length": 496,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "184",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182319.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230032.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 337,
+        "length": 337,
+        "eff_nseq": 0.64,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "187",
+        "names": [
+            "large protein",
+            "large polymerase subunit"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177604.1",
+                "name": "large protein",
+                "organism": "Phocine morbillivirus"
+            },
+            {
+                "accession": "YP_009179212.1",
+                "name": "large polymerase subunit",
+                "organism": "Caprine parainfluenza virus 3"
+            }
+        ],
+        "count": 2.0,
+        "alen": 2272,
+        "length": 2272,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Orthoparamyxovirinae": 1,
+            "Respirovirus": 1
+        },
+        "genera": {
+            "Morbillivirus": 1,
+            "Caprine respirovirus 3": 1
+        }
+    },
+    {
+        "cluster": "188",
+        "names": [
+            "tegument host shutoff protein",
+            "UL41 tegument host shutoff protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227274.1",
+                "name": "tegument host shutoff protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230172.1",
+                "name": "UL41 tegument host shutoff protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 528,
+        "length": 528,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "189",
+        "names": [
+            "helicase-primase subunit",
+            "helicase/primase complex associated protein UL8"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227241.1",
+                "name": "helicase-primase subunit",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230138.1",
+                "name": "helicase/primase complex associated protein UL8",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 758,
+        "length": 758,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "19",
+        "names": [
+            "replication enhancement protein",
+            "replication enhancer protein",
+            "replicase-associated protein"
+        ],
+        "entries": [
+            {
+                "accession": "NP_835273.1",
+                "name": "replicase-associated protein",
+                "organism": "Melon chlorotic leaf curl virus-"
+            },
+            {
+                "accession": "YP_009175076.1",
+                "name": "replication enhancement protein",
+                "organism": "Melochia mosaic virus"
+            },
+            {
+                "accession": "YP_009175083.1",
+                "name": "replication enhancement protein",
+                "organism": "Melochia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009177711.1",
+                "name": "replication enhancer protein",
+                "organism": "Andrographis yellow vein leaf curl virus"
+            },
+            {
+                "accession": "YP_009216261.1",
+                "name": "replication enhancement protein",
+                "organism": "Okra leaf curl Oman virus"
+            },
+            {
+                "accession": "YP_009216584.1",
+                "name": "AC3",
+                "organism": "Pepper yellow leaf curl Thailand virus"
+            },
+            {
+                "accession": "YP_009226415.1",
+                "name": "replication enhancer protein",
+                "organism": "Pavonia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009226625.1",
+                "name": "C3",
+                "organism": "Turnip leaf roll virus"
+            }
+        ],
+        "count": 8.0,
+        "alen": 145,
+        "length": 134,
+        "eff_nseq": 0.73,
+        "mean_entropy": 0.591,
+        "total_entropy": 4.73,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Geminiviridae": 8
+        },
+        "genera": {
+            "Begomovirus": 7,
+            "Turncurtovirus": 1
+        }
+    },
+    {
+        "cluster": "190",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182235.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229941.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 82,
+        "length": 82,
+        "eff_nseq": 0.64,
+        "mean_entropy": 0.692,
+        "total_entropy": 1.38,
+        "mean_positional_relative_entropy": 0.62,
+        "kullback_leibler_divergence": 0.08,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "191",
+        "names": [
+            "glycoprotein C",
+            "envelope glycoprotein C"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227276.1",
+                "name": "glycoprotein C",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230177.1",
+                "name": "envelope glycoprotein C",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 465,
+        "length": 465,
+        "eff_nseq": 0.64,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "192",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182227.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229962.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 239,
+        "length": 239,
+        "eff_nseq": 0.6,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "193",
+        "names": [
+            "tegument protein",
+            "UL21 tegument protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227254.1",
+                "name": "tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230152.1",
+                "name": "UL21 tegument protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 543,
+        "length": 543,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "194",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182288.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229999.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 369,
+        "length": 369,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "195",
+        "names": [
+            "tegument protein VP13/14",
+            "UL47 tegument protein/IE transactivator"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227279.1",
+                "name": "tegument protein VP13/14",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230180.1",
+                "name": "UL47 tegument protein/IE transactivator",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 715,
+        "length": 715,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "196",
+        "names": [
+            "DNA-helicase-2",
+            "helicase-2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182312.1",
+                "name": "DNA-helicase-2",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186748.1",
+                "name": "helicase-2",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 466,
+        "length": 466,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 1,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "198",
+        "names": [
+            "3D",
+            "NIb"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009220464.1",
+                "name": "3D",
+                "organism": "Tupaia hepatovirus A"
+            },
+            {
+                "accession": "YP_009221991.1",
+                "name": "NIb",
+                "organism": "Jasmine virus T"
+            }
+        ],
+        "count": 2.0,
+        "alen": 557,
+        "length": 557,
+        "eff_nseq": 0.65,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Hepatovirus": 1,
+            "Potyviridae": 1
+        },
+        "genera": {
+            "unclassified Hepatovirus": 1,
+            "Potyvirus": 1
+        }
+    },
+    {
+        "cluster": "199",
+        "names": [
+            "multifunctional expression regulator ICP27",
+            "UL54 multifunctional expression regulator"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227287.1",
+                "name": "multifunctional expression regulator ICP27",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230189.1",
+                "name": "UL54 multifunctional expression regulator",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 525,
+        "length": 525,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "2",
+        "names": [
+            "polymerase",
+            "putative RNA-dependent RNA polymerase"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177218.1",
+                "name": "polymerase",
+                "organism": "Suffolk virus"
+            },
+            {
+                "accession": "YP_009177701.1",
+                "name": "polymerase",
+                "organism": "Bole Tick Virus 3"
+            },
+            {
+                "accession": "YP_009177704.1",
+                "name": "polymerase",
+                "organism": "Changping Tick Virus 2"
+            },
+            {
+                "accession": "YP_009177707.1",
+                "name": "polymerase",
+                "organism": "Changping Tick Virus 3"
+            },
+            {
+                "accession": "YP_009177716.1",
+                "name": "polymerase",
+                "organism": "Tacheng Tick Virus 4"
+            },
+            {
+                "accession": "YP_009177717.1",
+                "name": "polymerase",
+                "organism": "Tacheng Tick Virus 5"
+            },
+            {
+                "accession": "YP_009177719.1",
+                "name": "polymerase",
+                "organism": "Wuhan Mosquito Virus 8"
+            },
+            {
+                "accession": "YP_009177722.1",
+                "name": "polymerase",
+                "organism": "Wuhan tick virus 2"
+            },
+            {
+                "accession": "YP_009182177.1",
+                "name": "putative RNA-dependent RNA polymerase",
+                "organism": "Imjin River virus 1"
+            }
+        ],
+        "count": 9.0,
+        "alen": 2316,
+        "length": 2171,
+        "eff_nseq": 1.13,
+        "mean_entropy": 0.588,
+        "total_entropy": 5.29,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Mivirus": 4,
+            "unclassified ssRNA viruses": 4,
+            "Rhabdoviridae": 1
+        },
+        "genera": {
+            "Suffolk mivirus": 1,
+            "unclassified ssRNA negative-strand viruses": 4,
+            "Argas mivirus": 1,
+            "Bole mivirus": 1,
+            "unclassified Rhabdoviridae": 1,
+            "Imjin mivirus": 1
+        }
+    },
+    {
+        "cluster": "20",
+        "names": [
+            "triple gene block protein 3"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009204564.1",
+                "name": "triple gene block protein 3",
+                "organism": "Asian prunus virus 2"
+            },
+            {
+                "accession": "YP_009215377.1",
+                "name": "triple gene block protein 3",
+                "organism": "Asian prunus virus 3"
+            },
+            {
+                "accession": "YP_009224931.1",
+                "name": "triple gene block protein 3",
+                "organism": "Elderberry carlavirus A"
+            },
+            {
+                "accession": "YP_009224937.1",
+                "name": "triple gene block protein 3",
+                "organism": "Elderberry carlavirus B"
+            },
+            {
+                "accession": "YP_009224943.1",
+                "name": "triple gene block protein 3",
+                "organism": "Elderberry carlavirus C"
+            },
+            {
+                "accession": "YP_009224949.1",
+                "name": "triple gene block protein 3",
+                "organism": "Elderberry carlavirus D"
+            },
+            {
+                "accession": "YP_009224955.1",
+                "name": "triple gene block protein 3",
+                "organism": "Elderberry carlavirus E"
+            }
+        ],
+        "count": 7.0,
+        "alen": 76,
+        "length": 71,
+        "eff_nseq": 1.67,
+        "mean_entropy": 0.794,
+        "total_entropy": 5.56,
+        "mean_positional_relative_entropy": 0.74,
+        "kullback_leibler_divergence": 0.07,
+        "families": {
+            "Foveavirus": 1,
+            "Quinvirinae": 4,
+            "Carlavirus": 2
+        },
+        "genera": {
+            "unclassified Foveavirus": 1,
+            "Foveavirus": 1,
+            "Carlavirus": 3,
+            "unclassified Carlavirus": 2
+        }
+    },
+    {
+        "cluster": "200",
+        "names": [
+            "putative nucleoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177721.1",
+                "name": "putative nucleoprotein",
+                "organism": "Wuhan Mosquito Virus 8"
+            },
+            {
+                "accession": "YP_009182179.1",
+                "name": "putative nucleoprotein",
+                "organism": "Imjin River virus 1"
+            }
+        ],
+        "count": 2.0,
+        "alen": 639,
+        "length": 639,
+        "eff_nseq": 0.47,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "unclassified ssRNA viruses": 1,
+            "Mivirus": 1
+        },
+        "genera": {
+            "unclassified ssRNA negative-strand viruses": 1,
+            "Imjin mivirus": 1
+        }
+    },
+    {
+        "cluster": "201",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182203.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229923.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 213,
+        "length": 213,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "202",
+        "names": [
+            "nuclear protein",
+            "nuclear protein UL55"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227288.1",
+                "name": "nuclear protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230190.1",
+                "name": "nuclear protein UL55",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 185,
+        "length": 185,
+        "eff_nseq": 0.58,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "203",
+        "names": [
+            "coat protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182166.1",
+                "name": "coat protein",
+                "organism": "Ustilaginoidea virens RNA virus 5"
+            },
+            {
+                "accession": "YP_009212847.1",
+                "name": "coat protein",
+                "organism": "Penicillium aurantiogriseum totivirus 1"
+            }
+        ],
+        "count": 2.0,
+        "alen": 786,
+        "length": 786,
+        "eff_nseq": 0.61,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Victorivirus": 1,
+            "Ghabrivirales": 1
+        },
+        "genera": {
+            "unclassified Victorivirus": 1,
+            "Totiviridae": 1
+        }
+    },
+    {
+        "cluster": "204",
+        "names": [
+            "envelope glycoprotein L",
+            "envelope glycoprotein UL1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227236.1",
+                "name": "envelope glycoprotein L",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230131.1",
+                "name": "envelope glycoprotein UL1",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 192,
+        "length": 192,
+        "eff_nseq": 0.53,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "205",
+        "names": [
+            "polyhedron envelope/P10 fusion protein",
+            "pep/p10"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182214.1",
+                "name": "polyhedron envelope/P10 fusion protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229936.1",
+                "name": "pep/p10",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 357,
+        "length": 357,
+        "eff_nseq": 0.52,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "206",
+        "names": [
+            "small capsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227268.1",
+                "name": "small capsid protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230165.1",
+                "name": "small capsid protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 135,
+        "length": 135,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "207",
+        "names": [
+            "glycoprotein K",
+            "envelope glycoprotein K"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227286.1",
+                "name": "glycoprotein K",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230188.1",
+                "name": "envelope glycoprotein K",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 342,
+        "length": 342,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "208",
+        "names": [
+            "N protein",
+            "nucleocapsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009176972.1",
+                "name": "nucleocapsid protein",
+                "organism": "Datura yellow vein nucleorhabdovirus"
+            },
+            {
+                "accession": "YP_009177222.1",
+                "name": "N protein",
+                "organism": "Barley yellow striate mosaic cytorhabdovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 463,
+        "length": 463,
+        "eff_nseq": 0.72,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Betarhabdovirinae": 1,
+            "Rhabdoviridae": 1
+        },
+        "genera": {
+            "Cytorhabdovirus": 1,
+            "Nucleorhabdovirus": 1
+        }
+    },
+    {
+        "cluster": "209",
+        "names": [
+            "tegument protein",
+            "tegument protein UL51"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227284.1",
+                "name": "tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230186.1",
+                "name": "tegument protein UL51",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 247,
+        "length": 247,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "21",
+        "names": [
+            "immediate early protein 1",
+            "nonstructural protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182204.1",
+                "name": "immediate early protein 1",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009480343.1",
+                "name": "nonstructural protein",
+                "organism": "Maize rough dwarf virus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 446,
+        "length": 446,
+        "eff_nseq": 0.72,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 1,
+            "Spinareovirinae": 1
+        },
+        "genera": {
+            "Betabaculovirus": 1,
+            "Fijivirus": 1
+        }
+    },
+    {
+        "cluster": "210",
+        "names": [
+            "capsid triplex subunit 1",
+            "UL38 capsid triplex subunit 1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227271.1",
+                "name": "capsid triplex subunit 1",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230168.1",
+                "name": "UL38 capsid triplex subunit 1",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 501,
+        "length": 501,
+        "eff_nseq": 0.54,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "211",
+        "names": [
+            "late expression factor 3",
+            "pif-6"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182297.1",
+                "name": "late expression factor 3",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230023.1",
+                "name": "pif-6",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 392,
+        "length": 392,
+        "eff_nseq": 0.63,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "213",
+        "names": [
+            "ac17",
+            "p22.2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186808.1",
+                "name": "ac17",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229945.1",
+                "name": "p22.2",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 247,
+        "length": 247,
+        "eff_nseq": 0.68,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "Betabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "214",
+        "names": [
+            "uracil-DNA glycosylase",
+            "uracil-DNA glycosylase UL2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227237.1",
+                "name": "uracil-DNA glycosylase",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230132.1",
+                "name": "uracil-DNA glycosylase UL2",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 319,
+        "length": 319,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "215",
+        "names": [
+            "p26-1",
+            "p26-2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186701.1",
+                "name": "p26-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009186747.1",
+                "name": "p26-2",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 304,
+        "length": 304,
+        "eff_nseq": 0.65,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "216",
+        "names": [
+            "replication-associated protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009226561.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular virus 1"
+            },
+            {
+                "accession": "YP_009226565.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular virus 3"
+            }
+        ],
+        "count": 2.0,
+        "alen": 323,
+        "length": 323,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "unclassified DNA viruses": 2
+        },
+        "genera": {
+            "unclassified ssDNA viruses": 2
+        }
+    },
+    {
+        "cluster": "217",
+        "names": [
+            "p48/p45",
+            "p45/p48"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186777.1",
+                "name": "p48/p45",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229984.1",
+                "name": "p45/p48",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 413,
+        "length": 413,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "Betabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "218",
+        "names": [
+            "E6"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177725.1",
+                "name": "E6",
+                "organism": "Trichechus manatus papillomavirus 4"
+            },
+            {
+                "accession": "YP_009182324.1",
+                "name": "E6",
+                "organism": "Rattus norvegicus papillomavirus 3"
+            }
+        ],
+        "count": 2.0,
+        "alen": 172,
+        "length": 172,
+        "eff_nseq": 0.59,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Firstpapillomavirinae": 2
+        },
+        "genera": {
+            "Rhopapillomavirus": 1,
+            "Iotapapillomavirus": 1
+        }
+    },
+    {
+        "cluster": "22",
+        "names": [
+            "single-stranded DNA binding protein",
+            "dbp-2",
+            "dbp-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182267.1",
+                "name": "single-stranded DNA binding protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186704.1",
+                "name": "dbp-2",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009186721.1",
+                "name": "dbp-1",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229980.1",
+                "name": "dbp",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 349,
+        "length": 310,
+        "eff_nseq": 1.22,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 4
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "220",
+        "names": [
+            "tegument protein",
+            "virion protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227220.1",
+                "name": "tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230197.1",
+                "name": "virion protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 360,
+        "length": 360,
+        "eff_nseq": 0.62,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "222",
+        "names": [
+            "hypothetical protein",
+            "pk-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182200.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229921.1",
+                "name": "pk-1",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 159,
+        "length": 159,
+        "eff_nseq": 0.67,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "223",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182242.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229956.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 67,
+        "length": 67,
+        "eff_nseq": 0.9,
+        "mean_entropy": 0.84,
+        "total_entropy": 1.68,
+        "mean_positional_relative_entropy": 0.78,
+        "kullback_leibler_divergence": 0.07,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "224",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182202.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009182257.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 87,
+        "length": 87,
+        "eff_nseq": 0.71,
+        "mean_entropy": 0.654,
+        "total_entropy": 1.31,
+        "mean_positional_relative_entropy": 0.58,
+        "kullback_leibler_divergence": 0.1,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "225",
+        "names": [
+            "alkaline exonuclease",
+            "deoxyribonuclease"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227245.1",
+                "name": "alkaline exonuclease",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230142.1",
+                "name": "deoxyribonuclease",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 606,
+        "length": 606,
+        "eff_nseq": 0.56,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "226",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182300.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230021.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 173,
+        "length": 173,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.06,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "227",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182248.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229950.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 66,
+        "length": 66,
+        "eff_nseq": 0.83,
+        "mean_entropy": 0.852,
+        "total_entropy": 1.7,
+        "mean_positional_relative_entropy": 0.78,
+        "kullback_leibler_divergence": 0.12,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "229",
+        "names": [
+            "late expression factor 6",
+            "lef-6"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182266.1",
+                "name": "late expression factor 6",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229979.1",
+                "name": "lef-6",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 116,
+        "length": 116,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "230",
+        "names": [
+            "hypothetical protein",
+            "dnapol"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182268.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009229981.1",
+                "name": "dnapol",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 89,
+        "length": 89,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.641,
+        "total_entropy": 1.28,
+        "mean_positional_relative_entropy": 0.56,
+        "kullback_leibler_divergence": 0.05,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "231",
+        "names": [
+            "nucleoprotein",
+            "sRNA nucleoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227130.1",
+                "name": "sRNA nucleoprotein",
+                "organism": "Adana virus"
+            },
+            {
+                "accession": "YP_009480532.1",
+                "name": "nucleoprotein",
+                "organism": "Arrabida virus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 256,
+        "length": 256,
+        "eff_nseq": 0.53,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Phlebovirus": 2
+        },
+        "genera": {
+            "unclassified Phlebovirus": 1,
+            "Adana phlebovirus": 1
+        }
+    },
+    {
+        "cluster": "232",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182309.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230014.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 104,
+        "length": 104,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "234",
+        "names": [
+            "tegument protein",
+            "tegument protein UL7"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009227240.1",
+                "name": "tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230137.1",
+                "name": "tegument protein UL7",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 295,
+        "length": 295,
+        "eff_nseq": 0.52,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "235",
+        "names": [
+            "ME53",
+            "me-53"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182323.1",
+                "name": "ME53",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009230037.1",
+                "name": "me-53",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 332,
+        "length": 332,
+        "eff_nseq": 0.48,
+        "mean_entropy": 0.587,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "236",
+        "names": [
+            "hypothetical protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009230129.1",
+                "name": "hypothetical protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            },
+            {
+                "accession": "YP_009230191.1",
+                "name": "hypothetical protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 149,
+        "length": 149,
+        "eff_nseq": 0.41,
+        "mean_entropy": 0.585,
+        "total_entropy": 1.17,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "237",
+        "names": [
+            "sod"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186793.1",
+                "name": "sod",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229947.1",
+                "name": "sod",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 170,
+        "length": 170,
+        "eff_nseq": 0.49,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "Betabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "24",
+        "names": [
+            "NS3-like protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009179379.1",
+                "name": "NS3-like protein",
+                "organism": "Wuhan aphid virus 2"
+            },
+            {
+                "accession": "YP_009179389.1",
+                "name": "NS3-like protein",
+                "organism": "Wuhan aphid virus 1"
+            },
+            {
+                "accession": "YP_009179400.1",
+                "name": "NS3-like protein",
+                "organism": "Wuhan cricket virus"
+            },
+            {
+                "accession": "YP_009179402.1",
+                "name": "NS3-like protein",
+                "organism": "Shuangao insect virus 7"
+            },
+            {
+                "accession": "YP_009179404.1",
+                "name": "NS3-like protein",
+                "organism": "Wuhan flea virus"
+            }
+        ],
+        "count": 5.0,
+        "alen": 828,
+        "length": 810,
+        "eff_nseq": 0.83,
+        "mean_entropy": 0.589,
+        "total_entropy": 2.94,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "unclassified ssRNA viruses": 5
+        },
+        "genera": {
+            "unclassified ssRNA positive-strand viruses": 5
+        }
+    },
+    {
+        "cluster": "25",
+        "names": [
+            "major outer structural protein",
+            "very large tegument protein, partial"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207097.1",
+                "name": "very large tegument protein, partial",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009480345.1",
+                "name": "major outer structural protein",
+                "organism": "Maize rough dwarf virus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 622,
+        "length": 622,
+        "eff_nseq": 0.73,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Spinareovirinae": 1,
+            "Alphaherpesvirinae": 1
+        },
+        "genera": {
+            "Fijivirus": 1,
+            "Scutavirus": 1
+        }
+    },
+    {
+        "cluster": "28",
+        "names": [
+            "glycoprotein",
+            "putative glycoprotein"
+        ],
+        "entries": [
             {
                 "accession": "YP_009177219.1",
                 "name": "putative glycoprotein",
@@ -221,769 +4734,194 @@
                 "accession": "YP_009177723.1",
                 "name": "glycoprotein",
                 "organism": "Wuhan tick virus 2"
-            },
-            {
-                "accession": "YP_009186790.1",
-                "name": "orf99",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009204554.1",
-                "name": "phosphoprotein",
-                "organism": "Fox fecal rhabdovirus"
             }
         ],
-        "count": 9.0,
-        "alen": 865,
-        "length": 662,
-        "eff_nseq": 2.29,
-        "mean_entropy": 0.589,
-        "total_entropy": 5.3,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
+        "count": 6.0,
+        "alen": 708,
+        "length": 664,
+        "eff_nseq": 1.03,
+        "mean_entropy": 0.59,
+        "total_entropy": 3.54,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
         "families": {
             "Mivirus": 3,
-            "Alpharhabdovirinae": 1,
             "unclassified ssRNA viruses": 2,
-            "Rhabdoviridae": 2,
-            "Baculoviridae": 1
+            "Rhabdoviridae": 1
         },
         "genera": {
             "Suffolk mivirus": 1,
-            "Ephemerovirus": 1,
             "unclassified ssRNA negative-strand viruses": 2,
             "Argas mivirus": 1,
             "Bole mivirus": 1,
-            "unclassified Rhabdoviridae": 2,
-            "Alphabaculovirus": 1
+            "unclassified Rhabdoviridae": 1
         }
     },
     {
-        "cluster": "100",
+        "cluster": "29",
         "names": [
-            "nuclear shuttle protein"
+            "putative nucleoprotein",
+            "ORF3"
         ],
         "entries": [
             {
-                "accession": "YP_009175072.1",
-                "name": "nuclear shuttle protein",
-                "organism": "Melon chlorotic leaf curl virus-"
+                "accession": "YP_009177220.1",
+                "name": "ORF3",
+                "organism": "Suffolk virus"
             },
             {
-                "accession": "YP_009175080.1",
-                "name": "nuclear shuttle protein",
-                "organism": "Melochia mosaic virus"
+                "accession": "YP_009177703.1",
+                "name": "putative nucleoprotein",
+                "organism": "Bole Tick Virus 3"
             },
             {
-                "accession": "YP_009175087.1",
-                "name": "nuclear shuttle protein",
-                "organism": "Melochia yellow mosaic virus"
+                "accession": "YP_009177706.1",
+                "name": "putative nucleoprotein",
+                "organism": "Changping Tick Virus 2"
             },
             {
-                "accession": "YP_009480522.1",
-                "name": "nuclear shuttle protein",
-                "organism": "Pavonia yellow mosaic virus"
+                "accession": "YP_009177708.1",
+                "name": "putative nucleoprotein",
+                "organism": "Changping Tick Virus 3"
+            },
+            {
+                "accession": "YP_009177718.1",
+                "name": "putative nucleoprotein",
+                "organism": "Tacheng Tick Virus 5"
+            },
+            {
+                "accession": "YP_009177724.1",
+                "name": "putative nucleoprotein",
+                "organism": "Wuhan tick virus 2"
             }
         ],
-        "count": 4.0,
-        "alen": 257,
-        "length": 256,
-        "eff_nseq": 0.46,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.35,
+        "count": 6.0,
+        "alen": 533,
+        "length": 425,
+        "eff_nseq": 1.14,
+        "mean_entropy": 0.59,
+        "total_entropy": 3.54,
         "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Geminiviridae": 4
-        },
-        "genera": {
-            "Begomovirus": 4
-        }
-    },
-    {
-        "cluster": "101",
-        "names": [
-            "putative major capsid protein",
-            "major capsid protein VP1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009216767.1",
-                "name": "putative major capsid protein",
-                "organism": "Gokushovirinae GAIR4"
-            },
-            {
-                "accession": "YP_009216768.1",
-                "name": "putative major capsid protein",
-                "organism": "Gokushovirinae GNX3R"
-            },
-            {
-                "accession": "YP_009218533.1",
-                "name": "major capsid protein VP1",
-                "organism": "Parabacteroides phage YZ-2015a"
-            },
-            {
-                "accession": "YP_009218802.1",
-                "name": "major capsid protein VP1",
-                "organism": "Parabacteroides phage YZ-2015b"
-            }
-        ],
-        "count": 4.0,
-        "alen": 623,
-        "length": 548,
-        "eff_nseq": 0.67,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.01,
         "families": {
-            "Gokushovirinae": 2,
-            "Microviridae": 2
+            "Mivirus": 2,
+            "unclassified ssRNA viruses": 3,
+            "Rhabdoviridae": 1
         },
         "genera": {
-            "unclassified Gokushovirinae": 2,
-            "unclassified Microviridae": 2
+            "Suffolk mivirus": 1,
+            "unclassified ssRNA negative-strand viruses": 3,
+            "Bole mivirus": 1,
+            "unclassified Rhabdoviridae": 1
         }
     },
     {
-        "cluster": "102",
+        "cluster": "3",
         "names": [
-            "me-53",
-            "ac56",
-            "glycoprotein E"
+            "RNA dependent RNA polymerase",
+            "putative RNA-dependent RNA polymerase"
         ],
         "entries": [
             {
-                "accession": "YP_009186707.1",
-                "name": "me-53",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
+                "accession": "YP_009182174.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 1"
             },
             {
-                "accession": "YP_009186734.1",
-                "name": "ac56",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
+                "accession": "YP_009182176.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 2"
             },
             {
-                "accession": "YP_009227226.1",
-                "name": "glycoprotein E",
-                "organism": "Macropodid alphaherpesvirus 1"
+                "accession": "YP_009182181.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 3"
             },
             {
-                "accession": "YP_009230201.1",
-                "name": "virion glycoprotein E",
-                "organism": "Leporid alphaherpesvirus 4"
+                "accession": "YP_009182188.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 5"
+            },
+            {
+                "accession": "YP_009182190.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 6"
+            },
+            {
+                "accession": "YP_009182195.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Red clover powdery mildew-associated totivirus 7"
+            },
+            {
+                "accession": "YP_009225665.1",
+                "name": "putative RNA-dependent RNA polymerase",
+                "organism": "Panax notoginseng virus A"
             }
         ],
-        "count": 4.0,
-        "alen": 586,
-        "length": 486,
-        "eff_nseq": 1.23,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 2,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "103",
-        "names": [
-            "phosphoprotein",
-            "putative 10 kDa protein",
-            "glycoprotein H"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176979.1",
-                "name": "phosphoprotein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009186839.1",
-                "name": "putative 10 kDa protein",
-                "organism": "Actinidia virus X"
-            },
-            {
-                "accession": "YP_009227255.1",
-                "name": "glycoprotein H",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230153.1",
-                "name": "envelope glycoprotein H",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 892,
-        "length": 497,
-        "eff_nseq": 1.23,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Sunrhavirus": 1,
-            "Alphaflexiviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Potexvirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "104",
-        "names": [
-            "odv-e18",
-            "phosphoprotein",
-            "ODV-E18"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179208.1",
-                "name": "phosphoprotein",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009182207.1",
-                "name": "ODV-E18",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186710.1",
-                "name": "odv-e18",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229930.1",
-                "name": "odv-e18",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 626,
-        "length": 121,
-        "eff_nseq": 1.06,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Respirovirus": 1,
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Caprine respirovirus 3": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "105",
-        "names": [
-            "phosphoprotein",
-            "P",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176967.1",
-                "name": "P",
-                "organism": "Inhangapi virus"
-            },
-            {
-                "accession": "YP_009177194.1",
-                "name": "phosphoprotein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177206.1",
-                "name": "phosphoprotein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009218536.1",
-                "name": "hypothetical protein",
-                "organism": "Parabacteroides phage YZ-2015a"
-            }
-        ],
-        "count": 4.0,
-        "alen": 318,
-        "length": 275,
-        "eff_nseq": 1.38,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alpharhabdovirinae": 2,
-            "Microviridae": 1
-        },
-        "genera": {
-            "Ephemerovirus": 2,
-            "unclassified Microviridae": 1
-        }
-    },
-    {
-        "cluster": "106",
-        "names": [
-            "lef-9",
-            "late expression factor 9",
-            "ac75"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182302.1",
-                "name": "late expression factor 9",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186740.1",
-                "name": "lef-9",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186755.1",
-                "name": "ac75",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230019.1",
-                "name": "lef-9",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 512,
-        "length": 495,
-        "eff_nseq": 0.7,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.35,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "107",
-        "names": [
-            "nuclear phosphoprotein",
-            "polyprotein",
-            "nuclear egress lamina protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207092.1",
-                "name": "nuclear phosphoprotein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009220370.1",
-                "name": "polyprotein",
-                "organism": "Currant latent virus"
-            },
-            {
-                "accession": "YP_009227129.1",
-                "name": "nonstructural protein",
-                "organism": "Adana virus"
-            },
-            {
-                "accession": "YP_009227264.1",
-                "name": "nuclear egress lamina protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            }
-        ],
-        "count": 4.0,
-        "alen": 963,
-        "length": 373,
+        "count": 7.0,
+        "alen": 876,
+        "length": 804,
         "eff_nseq": 1.32,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.45,
-        "kullback_leibler_divergence": 0.01,
+        "mean_entropy": 0.591,
+        "total_entropy": 4.14,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
         "families": {
-            "Alphaherpesvirinae": 2,
-            "Secoviridae": 1,
-            "Phlebovirus": 1
+            "Ghabrivirales": 7
         },
         "genera": {
-            "Scutavirus": 1,
-            "Cheravirus": 1,
-            "Simplexvirus": 1,
-            "Adana phlebovirus": 1
+            "Totiviridae": 7
         }
     },
     {
-        "cluster": "108",
+        "cluster": "30",
         "names": [
-            "nuclear egress membrane protein",
-            "p12",
-            "membrane-associated phosphoprotein"
+            "desmoplakin",
+            "orf1629"
         ],
         "entries": [
             {
-                "accession": "YP_009186776.1",
-                "name": "p12",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009207095.1",
-                "name": "membrane-associated phosphoprotein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227267.1",
-                "name": "nuclear egress membrane protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230164.1",
-                "name": "nuclear egress membrane protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 288,
-        "length": 269,
-        "eff_nseq": 1.36,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "109",
-        "names": [
-            "38K",
-            "38k",
-            "orf101"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182276.1",
-                "name": "38K",
+                "accession": "YP_009182296.1",
+                "name": "desmoplakin",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009186772.1",
-                "name": "38k",
+                "accession": "YP_009186693.1",
+                "name": "orf1629",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186792.1",
-                "name": "orf101",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229989.1",
-                "name": "lef-5",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 4.0,
-        "alen": 335,
-        "length": 301,
+        "count": 2.0,
+        "alen": 608,
+        "length": 608,
         "eff_nseq": 0.77,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.37,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.18,
         "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.04,
         "families": {
-            "Baculoviridae": 4
+            "Baculoviridae": 2
         },
         "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "11",
-        "names": [
-            "coat protein",
-            "small hydrophobic protein",
-            "AV1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175075.1",
-                "name": "coat protein",
-                "organism": "Melochia mosaic virus"
-            },
-            {
-                "accession": "YP_009175082.1",
-                "name": "coat protein",
-                "organism": "Melochia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009176983.1",
-                "name": "small hydrophobic protein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009177710.1",
-                "name": "coat protein",
-                "organism": "Andrographis yellow vein leaf curl virus"
-            },
-            {
-                "accession": "YP_009216260.1",
-                "name": "coat protein",
-                "organism": "Okra leaf curl Oman virus"
-            },
-            {
-                "accession": "YP_009216583.1",
-                "name": "AV1",
-                "organism": "Pepper yellow leaf curl Thailand virus"
-            },
-            {
-                "accession": "YP_009226414.1",
-                "name": "coat protein",
-                "organism": "Pavonia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009226568.1",
-                "name": "hypothetical protein",
-                "organism": "Ctenophore-associated circular virus 4"
-            },
-            {
-                "accession": "YP_009226624.1",
-                "name": "coat protein",
-                "organism": "Turnip leaf roll virus"
-            }
-        ],
-        "count": 9.0,
-        "alen": 302,
-        "length": 251,
-        "eff_nseq": 1.45,
-        "mean_entropy": 0.59,
-        "total_entropy": 5.31,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Geminiviridae": 7,
-            "Sunrhavirus": 1,
-            "unclassified DNA viruses": 1
-        },
-        "genera": {
-            "Begomovirus": 6,
-            "Walkabout sunrhavirus": 1,
-            "Turncurtovirus": 1,
-            "unclassified ssDNA viruses": 1
-        }
-    },
-    {
-        "cluster": "110",
-        "names": [
-            "p74",
-            "hypothetical protein",
-            "P74"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182224.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182251.1",
-                "name": "P74",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186706.1",
-                "name": "p74",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229946.1",
-                "name": "p74",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 707,
-        "length": 641,
-        "eff_nseq": 0.77,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.35,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 3,
+            "Betabaculovirus": 1,
             "Alphabaculovirus": 1
         }
     },
     {
-        "cluster": "111",
-        "names": [
-            "p49",
-            "P49",
-            "P13"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182208.1",
-                "name": "P49",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182239.1",
-                "name": "P13",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186709.1",
-                "name": "p49",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229931.1",
-                "name": "p49",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 508,
-        "length": 452,
-        "eff_nseq": 0.89,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "112",
-        "names": [
-            "protein kinase-1",
-            "pk-1",
-            "p78/83"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182201.1",
-                "name": "protein kinase-1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186694.1",
-                "name": "pk-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229922.1",
-                "name": "p78/83",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229998.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 275,
-        "length": 266,
-        "eff_nseq": 0.85,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "113",
-        "names": [
-            "late expression factor 6",
-            "orf91",
-            "structural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182266.1",
-                "name": "late expression factor 6",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186689.1",
-                "name": "structural protein",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009186782.1",
-                "name": "orf91",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229979.1",
-                "name": "lef-6",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 371,
-        "length": 342,
-        "eff_nseq": 1.37,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 3,
-            "Polyomaviridae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "Betapolyomavirus": 1
-        }
-    },
-    {
-        "cluster": "114",
+        "cluster": "32",
         "names": [
             "hypothetical protein",
             "chtb",
-            "chtB1"
+            "ac150"
         ],
         "entries": [
             {
                 "accession": "YP_009182206.1",
+                "name": "hypothetical protein",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009182262.1",
                 "name": "hypothetical protein",
                 "organism": "Diatraea saccharalis granulovirus"
             },
@@ -993,260 +4931,751 @@
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
+                "accession": "YP_009186749.1",
+                "name": "ac150",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
                 "accession": "YP_009229927.1",
                 "name": "chtB1",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229935.1",
-                "name": "pep-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 4.0,
-        "alen": 196,
-        "length": 104,
-        "eff_nseq": 0.67,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.06,
+        "count": 5.0,
+        "alen": 132,
+        "length": 99,
+        "eff_nseq": 0.98,
+        "mean_entropy": 0.591,
+        "total_entropy": 2.96,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.07,
         "families": {
-            "Baculoviridae": 4
+            "Baculoviridae": 5
         },
         "genera": {
             "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "115",
-        "names": [
-            "hypothetical protein",
-            "v-cath",
-            "ac76"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182292.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186746.1",
-                "name": "v-cath",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186756.1",
-                "name": "ac76",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230010.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 331,
-        "length": 114,
-        "eff_nseq": 0.99,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 2,
             "Alphabaculovirus": 2
         }
     },
     {
-        "cluster": "116",
+        "cluster": "33",
         "names": [
-            "hypothetical protein",
-            "membrane protein",
-            "membrane protein UL45"
+            "hypothetical protein ORF3",
+            "ORF4",
+            "non-structural protein 3b"
         ],
         "entries": [
             {
-                "accession": "YP_009182252.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
+                "accession": "YP_009194640.1",
+                "name": "ORF4",
+                "organism": "Camel alphacoronavirus"
             },
             {
-                "accession": "YP_009227277.1",
-                "name": "membrane protein",
-                "organism": "Macropodid alphaherpesvirus 1"
+                "accession": "YP_009199244.1",
+                "name": "non-structural protein 3b",
+                "organism": "Swine enteric coronavirus"
             },
             {
-                "accession": "YP_009230016.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
+                "accession": "YP_009199610.1",
+                "name": "hypothetical protein ORF3",
+                "organism": "BtMr-AlphaCoV/SAX2011"
             },
             {
-                "accession": "YP_009230178.1",
-                "name": "membrane protein UL45",
-                "organism": "Leporid alphaherpesvirus 4"
+                "accession": "YP_009199791.1",
+                "name": "hypothetical protein ORF3",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009200736.1",
+                "name": "hypothetical protein ORF3",
+                "organism": "BtRf-AlphaCoV/YN2012"
+            },
+            {
+                "accession": "YP_009201731.1",
+                "name": "hypothetical protein ORF3",
+                "organism": "BtNv-AlphaCoV/SC2013"
             }
         ],
-        "count": 4.0,
-        "alen": 196,
-        "length": 143,
-        "eff_nseq": 1.33,
+        "count": 6.0,
+        "alen": 249,
+        "length": 229,
+        "eff_nseq": 0.91,
         "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "117",
-        "names": [
-            "p18",
-            "P18",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182282.1",
-                "name": "P18",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182289.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186768.1",
-                "name": "p18",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229993.1",
-                "name": "p18",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 168,
-        "length": 157,
-        "eff_nseq": 1.0,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
+        "total_entropy": 3.54,
+        "mean_positional_relative_entropy": 0.52,
         "kullback_leibler_divergence": 0.05,
         "families": {
-            "Baculoviridae": 4
+            "Alphacoronavirus": 2,
+            "Rhinacovirus": 1,
+            "Decacovirus": 1,
+            "Nyctacovirus": 1,
+            "Myotacovirus": 1
         },
         "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
+            "Duvinacovirus": 1,
+            "Tegacovirus": 1,
+            "unclassified Rhinacovirus": 1,
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
+            "Myotis ricketti alphacoronavirus Sax-2011": 1
         }
     },
     {
-        "cluster": "118",
+        "cluster": "34",
         "names": [
-            "hypothetical protein",
-            "ac53"
+            "small envelope protein",
+            "envelope protein"
         ],
         "entries": [
             {
-                "accession": "YP_009182294.1",
-                "name": "hypothetical protein",
+                "accession": "YP_009194641.1",
+                "name": "envelope protein",
+                "organism": "Camel alphacoronavirus"
+            },
+            {
+                "accession": "YP_009199245.1",
+                "name": "envelope protein",
+                "organism": "Swine enteric coronavirus"
+            },
+            {
+                "accession": "YP_009199611.1",
+                "name": "small envelope protein",
+                "organism": "BtMr-AlphaCoV/SAX2011"
+            },
+            {
+                "accession": "YP_009199792.1",
+                "name": "small envelope protein",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009200737.1",
+                "name": "small envelope protein",
+                "organism": "BtRf-AlphaCoV/YN2012"
+            },
+            {
+                "accession": "YP_009201732.1",
+                "name": "small envelope protein",
+                "organism": "BtNv-AlphaCoV/SC2013"
+            }
+        ],
+        "count": 6.0,
+        "alen": 82,
+        "length": 76,
+        "eff_nseq": 0.79,
+        "mean_entropy": 0.745,
+        "total_entropy": 4.47,
+        "mean_positional_relative_entropy": 0.68,
+        "kullback_leibler_divergence": 0.13,
+        "families": {
+            "Alphacoronavirus": 2,
+            "Rhinacovirus": 1,
+            "Decacovirus": 1,
+            "Nyctacovirus": 1,
+            "Myotacovirus": 1
+        },
+        "genera": {
+            "Duvinacovirus": 1,
+            "Tegacovirus": 1,
+            "unclassified Rhinacovirus": 1,
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
+            "Myotis ricketti alphacoronavirus Sax-2011": 1
+        }
+    },
+    {
+        "cluster": "35",
+        "names": [
+            "polyhedron envelope protein 2",
+            "pep-2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182215.1",
+                "name": "polyhedron envelope protein 2",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009182318.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186729.1",
-                "name": "ac53",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230031.1",
-                "name": "hypothetical protein",
+                "accession": "YP_009229937.1",
+                "name": "pep-2",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
+        "count": 2.0,
+        "alen": 155,
+        "length": 155,
+        "eff_nseq": 0.51,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "37",
+        "names": [
+            "spike glycoprotein",
+            "spike protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009199242.1",
+                "name": "spike protein",
+                "organism": "Swine enteric coronavirus"
+            },
+            {
+                "accession": "YP_009199609.1",
+                "name": "spike glycoprotein",
+                "organism": "BtMr-AlphaCoV/SAX2011"
+            },
+            {
+                "accession": "YP_009199790.1",
+                "name": "spike glycoprotein",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009201730.1",
+                "name": "spike glycoprotein",
+                "organism": "BtNv-AlphaCoV/SC2013"
+            }
+        ],
         "count": 4.0,
-        "alen": 167,
-        "length": 138,
-        "eff_nseq": 1.0,
+        "alen": 1455,
+        "length": 1368,
+        "eff_nseq": 0.61,
+        "mean_entropy": 0.588,
+        "total_entropy": 2.35,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphacoronavirus": 1,
+            "Decacovirus": 1,
+            "Nyctacovirus": 1,
+            "Myotacovirus": 1
+        },
+        "genera": {
+            "Tegacovirus": 1,
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
+            "Myotis ricketti alphacoronavirus Sax-2011": 1
+        }
+    },
+    {
+        "cluster": "38",
+        "names": [
+            "RNA-dependent RNA polymerase",
+            "62 kDa protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009177217.1",
+                "name": "RNA-dependent RNA polymerase",
+                "organism": "Colletotrichum higginsianum non-segmented dsRNA virus 1"
+            },
+            {
+                "accession": "YP_009182336.1",
+                "name": "62 kDa protein",
+                "organism": "Penicillium aurantiogriseum partitivirus 1"
+            }
+        ],
+        "count": 2.0,
+        "alen": 623,
+        "length": 623,
+        "eff_nseq": 0.66,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Riboviria": 1,
+            "Partitiviridae": 1
+        },
+        "genera": {
+            "dsRNA viruses": 1,
+            "unclassified Partitiviridae": 1
+        }
+    },
+    {
+        "cluster": "39",
+        "names": [
+            "putative glycoprotein",
+            "nonstrutural protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009179381.1",
+                "name": "putative glycoprotein",
+                "organism": "Wuhan aphid virus 1"
+            },
+            {
+                "accession": "YP_009179393.1",
+                "name": "putative glycoprotein",
+                "organism": "Shuangao insect virus 7"
+            },
+            {
+                "accession": "YP_009179397.1",
+                "name": "putative glycoprotein",
+                "organism": "Wuhan flea virus"
+            },
+            {
+                "accession": "YP_009480531.1",
+                "name": "nonstrutural protein",
+                "organism": "Arrabida virus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 421,
+        "length": 320,
+        "eff_nseq": 1.27,
         "mean_entropy": 0.589,
         "total_entropy": 2.36,
         "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
+        "kullback_leibler_divergence": 0.02,
         "families": {
-            "Baculoviridae": 4
+            "unclassified ssRNA viruses": 3,
+            "Phlebovirus": 1
         },
         "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
+            "unclassified ssRNA positive-strand viruses": 3,
+            "unclassified Phlebovirus": 1
         }
     },
     {
-        "cluster": "119",
+        "cluster": "4",
         "names": [
-            "gG",
-            "17.5 kDa coat protein",
-            "envelope glycoprotein G"
+            "triple gene block protein 1"
         ],
         "entries": [
             {
-                "accession": "YP_009182171.1",
-                "name": "17.5 kDa coat protein",
-                "organism": "Tomato brown rugose fruit virus"
+                "accession": "YP_009186835.1",
+                "name": "triple gene block protein 1",
+                "organism": "Actinidia virus X"
             },
             {
-                "accession": "YP_009227222.1",
-                "name": "gG",
-                "organism": "Macropodid alphaherpesvirus 1"
+                "accession": "YP_009204562.1",
+                "name": "triple gene block protein 1",
+                "organism": "Asian prunus virus 2"
             },
             {
-                "accession": "YP_009227223.1",
-                "name": "gG",
-                "organism": "Macropodid alphaherpesvirus 1"
+                "accession": "YP_009215375.1",
+                "name": "triple gene block protein 1",
+                "organism": "Asian prunus virus 3"
             },
             {
-                "accession": "YP_009230198.1",
-                "name": "envelope glycoprotein G",
-                "organism": "Leporid alphaherpesvirus 4"
+                "accession": "YP_009224929.1",
+                "name": "triple gene block protein 1",
+                "organism": "Elderberry carlavirus A"
+            },
+            {
+                "accession": "YP_009224935.1",
+                "name": "triple gene block protein 1",
+                "organism": "Elderberry carlavirus B"
+            },
+            {
+                "accession": "YP_009224941.1",
+                "name": "triple gene block protein 1",
+                "organism": "Elderberry carlavirus C"
+            },
+            {
+                "accession": "YP_009224947.1",
+                "name": "triple gene block protein 1",
+                "organism": "Elderberry carlavirus D"
+            },
+            {
+                "accession": "YP_009224953.1",
+                "name": "triple gene block protein 1",
+                "organism": "Elderberry carlavirus E"
             }
         ],
-        "count": 4.0,
-        "alen": 841,
-        "length": 196,
-        "eff_nseq": 1.34,
+        "count": 8.0,
+        "alen": 252,
+        "length": 235,
+        "eff_nseq": 0.97,
         "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.42,
-        "kullback_leibler_divergence": 0.02,
+        "total_entropy": 4.73,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.01,
         "families": {
-            "Virgaviridae": 1,
-            "Alphaherpesvirinae": 3
+            "Alphaflexiviridae": 1,
+            "Foveavirus": 1,
+            "Quinvirinae": 4,
+            "Carlavirus": 2
         },
         "genera": {
-            "Tobamovirus": 1,
-            "Simplexvirus": 3
+            "Potexvirus": 1,
+            "unclassified Foveavirus": 1,
+            "Foveavirus": 1,
+            "Carlavirus": 3,
+            "unclassified Carlavirus": 2
         }
     },
     {
-        "cluster": "12",
+        "cluster": "42",
+        "names": [
+            "nucleic acid binding protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009224933.1",
+                "name": "nucleic acid binding protein",
+                "organism": "Elderberry carlavirus A"
+            },
+            {
+                "accession": "YP_009224939.1",
+                "name": "nucleic acid binding protein",
+                "organism": "Elderberry carlavirus B"
+            },
+            {
+                "accession": "YP_009224945.1",
+                "name": "nucleic acid binding protein",
+                "organism": "Elderberry carlavirus C"
+            },
+            {
+                "accession": "YP_009224951.1",
+                "name": "nucleic acid binding protein",
+                "organism": "Elderberry carlavirus D"
+            },
+            {
+                "accession": "YP_009224957.1",
+                "name": "nucleic acid binding protein",
+                "organism": "Elderberry carlavirus E"
+            }
+        ],
+        "count": 5.0,
+        "alen": 121,
+        "length": 105,
+        "eff_nseq": 0.82,
+        "mean_entropy": 0.592,
+        "total_entropy": 2.96,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Quinvirinae": 3,
+            "Carlavirus": 2
+        },
+        "genera": {
+            "Carlavirus": 3,
+            "unclassified Carlavirus": 2
+        }
+    },
+    {
+        "cluster": "43",
+        "names": [
+            "nucleocapsid protein",
+            "nucleoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009194643.1",
+                "name": "nucleocapsid protein",
+                "organism": "Camel alphacoronavirus"
+            },
+            {
+                "accession": "YP_009199247.1",
+                "name": "nucleoprotein",
+                "organism": "Swine enteric coronavirus"
+            },
+            {
+                "accession": "YP_009199613.1",
+                "name": "nucleocapsid protein",
+                "organism": "BtMr-AlphaCoV/SAX2011"
+            },
+            {
+                "accession": "YP_009199794.1",
+                "name": "nucleocapsid protein",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009200739.1",
+                "name": "nucleocapsid protein",
+                "organism": "BtRf-AlphaCoV/YN2012"
+            },
+            {
+                "accession": "YP_009201734.1",
+                "name": "nucleocapsid protein",
+                "organism": "BtNv-AlphaCoV/SC2013"
+            }
+        ],
+        "count": 6.0,
+        "alen": 472,
+        "length": 393,
+        "eff_nseq": 0.84,
+        "mean_entropy": 0.591,
+        "total_entropy": 3.55,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Alphacoronavirus": 2,
+            "Rhinacovirus": 1,
+            "Decacovirus": 1,
+            "Nyctacovirus": 1,
+            "Myotacovirus": 1
+        },
+        "genera": {
+            "Duvinacovirus": 1,
+            "Tegacovirus": 1,
+            "unclassified Rhinacovirus": 1,
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
+            "Myotis ricketti alphacoronavirus Sax-2011": 1
+        }
+    },
+    {
+        "cluster": "44",
+        "names": [
+            "NS1",
+            "nonstructural protein",
+            "nonstructural protein 1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009175068.1",
+                "name": "nonstructural protein",
+                "organism": "Ungulate tetraparvovirus 1"
+            },
+            {
+                "accession": "YP_009186840.1",
+                "name": "NS1",
+                "organism": "Rat bufavirus SY-2015"
+            },
+            {
+                "accession": "YP_009215301.1",
+                "name": "nonstructural protein 1",
+                "organism": "Lagomorph bocaparvovirus 1"
+            },
+            {
+                "accession": "YP_009227291.1",
+                "name": "NS1",
+                "organism": "Rat bocavirus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 874,
+        "length": 667,
+        "eff_nseq": 1.13,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Parvovirinae": 3,
+            "Bocaparvovirus": 1
+        },
+        "genera": {
+            "Tetraparvovirus": 1,
+            "Protoparvovirus": 1,
+            "Bocaparvovirus": 1,
+            "Rodent bocaparvovirus 1": 1
+        }
+    },
+    {
+        "cluster": "45",
+        "names": [
+            "matrix protein",
+            "M"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009176968.1",
+                "name": "M",
+                "organism": "Inhangapi virus"
+            },
+            {
+                "accession": "YP_009177012.1",
+                "name": "M",
+                "organism": "Kumasi rhabdovirus"
+            },
+            {
+                "accession": "YP_009177195.1",
+                "name": "matrix protein",
+                "organism": "Koolpinyah virus"
+            },
+            {
+                "accession": "YP_009177207.1",
+                "name": "matrix protein",
+                "organism": "Yata virus"
+            },
+            {
+                "accession": "YP_009177241.1",
+                "name": "matrix protein",
+                "organism": "Adelaide River virus"
+            }
+        ],
+        "count": 5.0,
+        "alen": 231,
+        "length": 217,
+        "eff_nseq": 1.33,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.95,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Rhabdoviridae": 1,
+            "Alpharhabdovirinae": 4
+        },
+        "genera": {
+            "unclassified Rhabdoviridae": 1,
+            "Ephemerovirus": 3,
+            "Ledantevirus": 1
+        }
+    },
+    {
+        "cluster": "47",
+        "names": [
+            "AC4 protein",
+            "AC4",
+            "C4 protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009175079.1",
+                "name": "AC4 protein",
+                "organism": "Melochia mosaic virus"
+            },
+            {
+                "accession": "YP_009175086.1",
+                "name": "AC4 protein",
+                "organism": "Melochia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009216264.1",
+                "name": "C4 protein",
+                "organism": "Okra leaf curl Oman virus"
+            },
+            {
+                "accession": "YP_009216587.1",
+                "name": "AC4",
+                "organism": "Pepper yellow leaf curl Thailand virus"
+            },
+            {
+                "accession": "YP_009226418.1",
+                "name": "ac4 protein",
+                "organism": "Pavonia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009226628.1",
+                "name": "C4",
+                "organism": "Turnip leaf roll virus"
+            }
+        ],
+        "count": 6.0,
+        "alen": 99,
+        "length": 85,
+        "eff_nseq": 1.4,
+        "mean_entropy": 0.669,
+        "total_entropy": 4.01,
+        "mean_positional_relative_entropy": 0.63,
+        "kullback_leibler_divergence": 0.06,
+        "families": {
+            "Geminiviridae": 6
+        },
+        "genera": {
+            "Begomovirus": 5,
+            "Turncurtovirus": 1
+        }
+    },
+    {
+        "cluster": "48",
+        "names": [
+            "djbp",
+            "39k"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186726.1",
+                "name": "djbp",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229949.1",
+                "name": "39k",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 2.0,
+        "alen": 429,
+        "length": 429,
+        "eff_nseq": 0.79,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Alphabaculovirus": 1,
+            "Betabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "49",
+        "names": [
+            "membrane glycoprotein",
+            "membrane protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009194642.1",
+                "name": "membrane protein",
+                "organism": "Camel alphacoronavirus"
+            },
+            {
+                "accession": "YP_009199246.1",
+                "name": "membrane protein",
+                "organism": "Swine enteric coronavirus"
+            },
+            {
+                "accession": "YP_009199612.1",
+                "name": "membrane glycoprotein",
+                "organism": "BtMr-AlphaCoV/SAX2011"
+            },
+            {
+                "accession": "YP_009199793.1",
+                "name": "membrane glycoprotein",
+                "organism": "BtRf-AlphaCoV/HuB2013"
+            },
+            {
+                "accession": "YP_009200738.1",
+                "name": "membrane glycoprotein",
+                "organism": "BtRf-AlphaCoV/YN2012"
+            },
+            {
+                "accession": "YP_009201733.1",
+                "name": "membrane glycoprotein",
+                "organism": "BtNv-AlphaCoV/SC2013"
+            }
+        ],
+        "count": 6.0,
+        "alen": 263,
+        "length": 228,
+        "eff_nseq": 0.52,
+        "mean_entropy": 0.59,
+        "total_entropy": 3.54,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.04,
+        "families": {
+            "Alphacoronavirus": 2,
+            "Rhinacovirus": 1,
+            "Decacovirus": 1,
+            "Nyctacovirus": 1,
+            "Myotacovirus": 1
+        },
+        "genera": {
+            "Duvinacovirus": 1,
+            "Tegacovirus": 1,
+            "unclassified Rhinacovirus": 1,
+            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
+            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
+            "Myotis ricketti alphacoronavirus Sax-2011": 1
+        }
+    },
+    {
+        "cluster": "5",
         "names": [
             "replication associated protein",
             "replication-associated protein",
@@ -1292,265 +5721,396 @@
                 "accession": "YP_009226627.1",
                 "name": "Rep",
                 "organism": "Turnip leaf roll virus"
-            },
-            {
-                "accession": "YP_009229914.1",
-                "name": "structural protein",
-                "organism": "Piscine myocarditis-like virus"
             }
         ],
-        "count": 9.0,
-        "alen": 827,
-        "length": 382,
-        "eff_nseq": 0.93,
-        "mean_entropy": 0.592,
-        "total_entropy": 5.33,
-        "mean_positional_relative_entropy": 0.5,
+        "count": 8.0,
+        "alen": 379,
+        "length": 359,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.591,
+        "total_entropy": 4.73,
+        "mean_positional_relative_entropy": 0.52,
         "kullback_leibler_divergence": 0.01,
         "families": {
-            "Geminiviridae": 8,
-            "Ghabrivirales": 1
+            "Geminiviridae": 8
         },
         "genera": {
             "Begomovirus": 7,
-            "Turncurtovirus": 1,
-            "Totiviridae": 1
+            "Turncurtovirus": 1
         }
     },
     {
-        "cluster": "120",
+        "cluster": "50",
         "names": [
-            "hypothetical protein"
+            "inhibitor of apoptosis 3",
+            "inhibitor of apoptosis 5",
+            "iap-3"
         ],
         "entries": [
             {
-                "accession": "YP_009182320.1",
-                "name": "hypothetical protein",
+                "accession": "YP_009182263.1",
+                "name": "inhibitor of apoptosis 3",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009227227.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
+                "accession": "YP_009182301.1",
+                "name": "inhibitor of apoptosis 5",
+                "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009229928.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
+                "accession": "YP_009186727.1",
+                "name": "iap-3",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009230033.1",
-                "name": "hypothetical protein",
+                "accession": "YP_009186750.1",
+                "name": "iap-2",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230020.1",
+                "name": "iap-5",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 4.0,
-        "alen": 675,
-        "length": 151,
-        "eff_nseq": 1.35,
+        "count": 5.0,
+        "alen": 377,
+        "length": 268,
+        "eff_nseq": 1.02,
         "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.03,
+        "total_entropy": 2.95,
+        "mean_positional_relative_entropy": 0.49,
+        "kullback_leibler_divergence": 0.05,
         "families": {
-            "Baculoviridae": 3,
-            "Alphaherpesvirinae": 1
+            "Baculoviridae": 5
         },
         "genera": {
             "Betabaculovirus": 3,
-            "Simplexvirus": 1
+            "Alphabaculovirus": 2
         }
     },
     {
-        "cluster": "121",
+        "cluster": "51",
         "names": [
-            "hypothetical protein 2",
-            "175 kDa protein",
-            "174 kDa protein"
+            "membrane protein",
+            "ORF4' protein",
+            "membrane protein UL45"
         ],
         "entries": [
             {
-                "accession": "YP_009177009.1",
-                "name": "hypothetical protein 2",
-                "organism": "Kumasi rhabdovirus"
+                "accession": "YP_009221998.1",
+                "name": "ORF4' protein",
+                "organism": "Kafue kinda chacma baboon virus"
             },
             {
-                "accession": "YP_009182154.1",
-                "name": "174 kDa protein",
-                "organism": "Penicillium aurantiogriseum fusarivirus 1"
+                "accession": "YP_009227277.1",
+                "name": "membrane protein",
+                "organism": "Macropodid alphaherpesvirus 1"
             },
             {
-                "accession": "YP_009182158.1",
-                "name": "175 kDa protein",
-                "organism": "Pleospora typhicola fusarivirus 1"
+                "accession": "YP_009230178.1",
+                "name": "membrane protein UL45",
+                "organism": "Leporid alphaherpesvirus 4"
             }
         ],
         "count": 3.0,
-        "alen": 1584,
-        "length": 1523,
-        "eff_nseq": 0.76,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
+        "alen": 203,
+        "length": 161,
+        "eff_nseq": 0.84,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.5,
+        "kullback_leibler_divergence": 0.03,
         "families": {
-            "Alpharhabdovirinae": 1,
-            "unclassified ssRNA viruses": 2
+            "Alphaherpesvirinae": 2,
+            "Kaftartevirus": 1
         },
         "genera": {
-            "Ledantevirus": 1,
-            "Fusariviridae": 2
+            "Simplexvirus": 2,
+            "Thetaarterivirus kafuba": 1
         }
     },
     {
-        "cluster": "122",
+        "cluster": "53",
         "names": [
             "DNA-helicase-2",
-            "helicase-2",
-            "nuclear phosphoprotein UL3"
+            "helicase"
         ],
         "entries": [
             {
-                "accession": "YP_009182312.1",
+                "accession": "YP_009182280.1",
                 "name": "DNA-helicase-2",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009186748.1",
-                "name": "helicase-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230133.1",
-                "name": "nuclear phosphoprotein UL3",
-                "organism": "Leporid alphaherpesvirus 4"
+                "accession": "YP_009229991.1",
+                "name": "helicase",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 3.0,
-        "alen": 467,
-        "length": 422,
-        "eff_nseq": 0.86,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
+        "count": 2.0,
+        "alen": 1171,
+        "length": 1171,
+        "eff_nseq": 0.5,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
         "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 1
+            "Baculoviridae": 2
         },
         "genera": {
-            "Betabaculovirus": 1,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 1
+            "Betabaculovirus": 2
         }
     },
     {
-        "cluster": "123",
+        "cluster": "54",
         "names": [
-            "acetyltransferase-like protein",
-            "orf105",
+            "putative capsid protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009179382.1",
+                "name": "putative capsid protein",
+                "organism": "Wuhan aphid virus 1"
+            },
+            {
+                "accession": "YP_009179386.1",
+                "name": "putative capsid protein",
+                "organism": "Wuhan aphid virus 2"
+            },
+            {
+                "accession": "YP_009179394.1",
+                "name": "putative capsid protein",
+                "organism": "Shuangao insect virus 7"
+            },
+            {
+                "accession": "YP_009179398.1",
+                "name": "putative capsid protein",
+                "organism": "Wuhan flea virus"
+            },
+            {
+                "accession": "YP_009179408.1",
+                "name": "putative capsid protein",
+                "organism": "Wuhan cricket virus"
+            }
+        ],
+        "count": 5.0,
+        "alen": 277,
+        "length": 260,
+        "eff_nseq": 1.2,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.95,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "unclassified ssRNA viruses": 5
+        },
+        "genera": {
+            "unclassified ssRNA positive-strand viruses": 5
+        }
+    },
+    {
+        "cluster": "55",
+        "names": [
+            "p47",
+            "P47"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182255.1",
+                "name": "P47",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186722.1",
+                "name": "p47",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229969.1",
+                "name": "p47",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 418,
+        "length": 391,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "56",
+        "names": [
+            "p74",
+            "P74"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182251.1",
+                "name": "P74",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186706.1",
+                "name": "p74",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229946.1",
+                "name": "p74",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 707,
+        "length": 664,
+        "eff_nseq": 0.57,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "57",
+        "names": [
             "hypothetical protein"
         ],
         "entries": [
             {
-                "accession": "YP_009182253.1",
-                "name": "acetyltransferase-like protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186796.1",
-                "name": "orf105",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229944.1",
+                "accession": "YP_009179383.1",
                 "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
+                "organism": "Wuhan aphid virus 1"
+            },
+            {
+                "accession": "YP_009179387.1",
+                "name": "hypothetical protein",
+                "organism": "Wuhan aphid virus 2"
+            },
+            {
+                "accession": "YP_009179395.1",
+                "name": "hypothetical protein",
+                "organism": "Shuangao insect virus 7"
+            },
+            {
+                "accession": "YP_009179399.1",
+                "name": "hypothetical protein",
+                "organism": "Wuhan flea virus"
+            },
+            {
+                "accession": "YP_009179409.1",
+                "name": "hypothetical protein",
+                "organism": "Wuhan cricket virus"
             }
         ],
-        "count": 3.0,
-        "alen": 457,
-        "length": 302,
-        "eff_nseq": 0.86,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
+        "count": 5.0,
+        "alen": 608,
+        "length": 530,
+        "eff_nseq": 1.23,
+        "mean_entropy": 0.59,
+        "total_entropy": 2.95,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.02,
         "families": {
-            "Baculoviridae": 3
+            "unclassified ssRNA viruses": 5
         },
         "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
+            "unclassified ssRNA positive-strand viruses": 5
         }
     },
     {
-        "cluster": "124",
+        "cluster": "58",
         "names": [
-            "lef-8",
-            "late expression factor 8"
+            "NS5-like protein"
         ],
         "entries": [
             {
-                "accession": "YP_009182317.1",
-                "name": "late expression factor 8",
-                "organism": "Diatraea saccharalis granulovirus"
+                "accession": "YP_009179378.1",
+                "name": "NS5-like protein",
+                "organism": "Wuhan aphid virus 2"
             },
             {
-                "accession": "YP_009186724.1",
-                "name": "lef-8",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
+                "accession": "YP_009179388.1",
+                "name": "NS5-like protein",
+                "organism": "Wuhan aphid virus 1"
             },
             {
-                "accession": "YP_009230028.1",
-                "name": "lef-8",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
+                "accession": "YP_009179401.1",
+                "name": "NS5-like protein",
+                "organism": "Shuangao insect virus 7"
+            },
+            {
+                "accession": "YP_009179403.1",
+                "name": "NS5-like protein",
+                "organism": "Wuhan flea virus"
+            },
+            {
+                "accession": "YP_009179405.1",
+                "name": "NS5-like protein",
+                "organism": "Wuhan cricket virus"
             }
         ],
-        "count": 3.0,
-        "alen": 933,
-        "length": 854,
-        "eff_nseq": 0.5,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
+        "count": 5.0,
+        "alen": 951,
+        "length": 907,
+        "eff_nseq": 0.66,
+        "mean_entropy": 0.592,
+        "total_entropy": 2.96,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.01,
         "families": {
-            "Baculoviridae": 3
+            "unclassified ssRNA viruses": 5
         },
         "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
+            "unclassified ssRNA positive-strand viruses": 5
         }
     },
     {
-        "cluster": "125",
+        "cluster": "59",
         "names": [
-            "chaB",
-            "DNA packaging tegument protein UL17"
+            "cg30-2",
+            "cg30-1",
+            "thymidylate synthase"
         ],
         "entries": [
             {
-                "accession": "YP_009186736.1",
-                "name": "chaB",
+                "accession": "YP_009186699.1",
+                "name": "cg30-2",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009186737.1",
-                "name": "chaB",
+                "accession": "YP_009186763.1",
+                "name": "cg30-1",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009230147.1",
-                "name": "DNA packaging tegument protein UL17",
-                "organism": "Leporid alphaherpesvirus 4"
+                "accession": "YP_009227216.1",
+                "name": "thymidylate synthase",
+                "organism": "Macropodid alphaherpesvirus 1"
             }
         ],
         "count": 3.0,
-        "alen": 399,
-        "length": 266,
-        "eff_nseq": 1.1,
-        "mean_entropy": 0.591,
+        "alen": 355,
+        "length": 288,
+        "eff_nseq": 1.3,
+        "mean_entropy": 0.59,
         "total_entropy": 1.77,
         "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.03,
@@ -1564,170 +6124,7 @@
         }
     },
     {
-        "cluster": "126",
-        "names": [
-            "53 kDa protein",
-            "transactivating tegument protein VP16",
-            "UL48 transactivating tegument protein VP16"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182155.1",
-                "name": "53 kDa protein",
-                "organism": "Penicillium aurantiogriseum fusarivirus 1"
-            },
-            {
-                "accession": "YP_009227280.1",
-                "name": "transactivating tegument protein VP16",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230181.1",
-                "name": "UL48 transactivating tegument protein VP16",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 572,
-        "length": 489,
-        "eff_nseq": 1.02,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified ssRNA viruses": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Fusariviridae": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "127",
-        "names": [
-            "DNA polymerase",
-            "dna polymerase",
-            "desmoplakin"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182295.1",
-                "name": "DNA polymerase",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186754.1",
-                "name": "dna polymerase",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230026.1",
-                "name": "desmoplakin",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 1169,
-        "length": 1029,
-        "eff_nseq": 0.65,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.78,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "128",
-        "names": [
-            "RNA-dependent RNA polymerase",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182278.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009224693.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Arrabida virus"
-            },
-            {
-                "accession": "YP_009227127.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Adana virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 2107,
-        "length": 2090,
-        "eff_nseq": 0.65,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 1,
-            "Phlebovirus": 2
-        },
-        "genera": {
-            "Betabaculovirus": 1,
-            "unclassified Phlebovirus": 1,
-            "Adana phlebovirus": 1
-        }
-    },
-    {
-        "cluster": "129",
-        "names": [
-            "late expression factor 3",
-            "pif-6",
-            "nuclear protein ul4"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182297.1",
-                "name": "late expression factor 3",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230023.1",
-                "name": "pif-6",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230134.1",
-                "name": "nuclear protein ul4",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 394,
-        "length": 333,
-        "eff_nseq": 0.99,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "13",
+        "cluster": "6",
         "names": [
             "triple gene block protein 2"
         ],
@@ -1803,7376 +6200,7 @@
         }
     },
     {
-        "cluster": "130",
-        "names": [
-            "ubiquitin",
-            "ubiquitin-like protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182246.1",
-                "name": "ubiquitin-like protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186717.1",
-                "name": "ubiquitin",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229952.1",
-                "name": "ubiquitin",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 118,
-        "length": 95,
-        "eff_nseq": 0.48,
-        "mean_entropy": 0.602,
-        "total_entropy": 1.81,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "131",
-        "names": [
-            "vp39",
-            "VP39"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182285.1",
-                "name": "VP39",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186764.1",
-                "name": "vp39",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229996.1",
-                "name": "vp39",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 338,
-        "length": 290,
-        "eff_nseq": 0.65,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "132",
-        "names": [
-            "hemagglutinin-neuraminidase",
-            "DNA replication origin-binding helicase",
-            "DNA replication origin-binding helicase UL9"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179211.1",
-                "name": "hemagglutinin-neuraminidase",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009227242.1",
-                "name": "DNA replication origin-binding helicase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230139.1",
-                "name": "DNA replication origin-binding helicase UL9",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 883,
-        "length": 829,
-        "eff_nseq": 0.78,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Respirovirus": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Caprine respirovirus 3": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "133",
-        "names": [
-            "p47",
-            "P47"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182255.1",
-                "name": "P47",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186722.1",
-                "name": "p47",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229969.1",
-                "name": "p47",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 418,
-        "length": 391,
-        "eff_nseq": 0.55,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "134",
-        "names": [
-            "P3 protein",
-            "protein kinase",
-            "serine/threonine protein kinase US3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009221985.1",
-                "name": "P3 protein",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009227221.1",
-                "name": "protein kinase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230196.1",
-                "name": "serine/threonine protein kinase US3",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 786,
-        "length": 499,
-        "eff_nseq": 0.88,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Potyviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Potyvirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "135",
-        "names": [
-            "alk-exo",
-            "alkaline exonuclease"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182311.1",
-                "name": "alkaline exonuclease",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186816.1",
-                "name": "alk-exo",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230013.1",
-                "name": "alk-exo",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 470,
-        "length": 407,
-        "eff_nseq": 0.7,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "136",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009229965.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229966.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230011.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 392,
-        "length": 369,
-        "eff_nseq": 0.81,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "137",
-        "names": [
-            "pif-4",
-            "ODV-E28"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182279.1",
-                "name": "ODV-E28",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186771.1",
-                "name": "pif-4",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229990.1",
-                "name": "pif-4",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 178,
-        "length": 161,
-        "eff_nseq": 0.62,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "138",
-        "names": [
-            "hypothetical protein",
-            "ac110"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182245.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186779.1",
-                "name": "ac110",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229953.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 58,
-        "length": 49,
-        "eff_nseq": 1.39,
-        "mean_entropy": 1.129,
-        "total_entropy": 3.39,
-        "mean_positional_relative_entropy": 1.06,
-        "kullback_leibler_divergence": 0.16,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "139",
-        "names": [
-            "BV-E31",
-            "bv-e31",
-            "BV-e31"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182256.1",
-                "name": "BV-E31",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186720.1",
-                "name": "bv-e31",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229970.1",
-                "name": "BV-e31",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 269,
-        "length": 217,
-        "eff_nseq": 0.54,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "14",
-        "names": [
-            "hypothetical protein",
-            "L2",
-            "late expression factor 10"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177729.1",
-                "name": "L2",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182213.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182321.1",
-                "name": "late expression factor 10",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009221993.1",
-                "name": "putative 1b protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009221994.1",
-                "name": "1a replicase protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009221995.1",
-                "name": "putative nsp2F protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009230182.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230207.1",
-                "name": "capsid protein",
-                "organism": "Camponotus nipponicus virus"
-            }
-        ],
-        "count": 8.0,
-        "alen": 3554,
-        "length": 769,
-        "eff_nseq": 2.01,
-        "mean_entropy": 0.589,
-        "total_entropy": 4.71,
-        "mean_positional_relative_entropy": 0.42,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Firstpapillomavirinae": 1,
-            "Baculoviridae": 2,
-            "Kaftartevirus": 3,
-            "Alphaherpesvirinae": 1,
-            "Ghabrivirales": 1
-        },
-        "genera": {
-            "Rhopapillomavirus": 1,
-            "Betabaculovirus": 2,
-            "Thetaarterivirus kafuba": 3,
-            "Simplexvirus": 1,
-            "Totiviridae": 1
-        }
-    },
-    {
-        "cluster": "140",
-        "names": [
-            "C'' protein",
-            "VP1",
-            "VP2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176981.1",
-                "name": "C'' protein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009186841.1",
-                "name": "VP1",
-                "organism": "Rat bufavirus SY-2015"
-            },
-            {
-                "accession": "YP_009186842.1",
-                "name": "VP2",
-                "organism": "Rat bufavirus SY-2015"
-            }
-        ],
-        "count": 3.0,
-        "alen": 726,
-        "length": 726,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Sunrhavirus": 1,
-            "Parvovirinae": 2
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Protoparvovirus": 2
-        }
-    },
-    {
-        "cluster": "141",
-        "names": [
-            "fgf",
-            "fgf-1",
-            "fgf-3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186818.1",
-                "name": "fgf",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229975.1",
-                "name": "fgf-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230036.1",
-                "name": "fgf-3",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 403,
-        "length": 335,
-        "eff_nseq": 1.13,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "142",
-        "names": [
-            "virion membrane glycoprotein B",
-            "glycoprotein B",
-            "envelope glycoprotein B-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207088.1",
-                "name": "virion membrane glycoprotein B",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227260.1",
-                "name": "glycoprotein B",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230158.1",
-                "name": "envelope glycoprotein B-1",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 944,
-        "length": 870,
-        "eff_nseq": 0.64,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "143",
-        "names": [
-            "DNA cleavage/packaging protein",
-            "DNA packaging protein",
-            "DNA packaging protein UL32"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207093.1",
-                "name": "DNA cleavage/packaging protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227265.1",
-                "name": "DNA packaging protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230162.1",
-                "name": "DNA packaging protein UL32",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 665,
-        "length": 547,
-        "eff_nseq": 0.62,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.78,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "144",
-        "names": [
-            "polyprotein",
-            "tegument protein VP13/14",
-            "UL47 tegument protein/IE transactivator"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175091.1",
-                "name": "polyprotein",
-                "organism": "Bean rugose mosaic virus"
-            },
-            {
-                "accession": "YP_009227279.1",
-                "name": "tegument protein VP13/14",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230180.1",
-                "name": "UL47 tegument protein/IE transactivator",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 1114,
-        "length": 708,
-        "eff_nseq": 0.93,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Comovirinae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Comovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "145",
-        "names": [
-            "DNA polymerase",
-            "DNA polymerase catalytic subunit"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207091.1",
-                "name": "DNA polymerase catalytic subunit",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227263.1",
-                "name": "DNA polymerase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230161.1",
-                "name": "DNA polymerase",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 1239,
-        "length": 1207,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "146",
-        "names": [
-            "ICP22",
-            "regulatory protein ICP22",
-            "US11 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227219.1",
-                "name": "ICP22",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230195.1",
-                "name": "regulatory protein ICP22",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230203.1",
-                "name": "US11 protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 498,
-        "length": 323,
-        "eff_nseq": 0.93,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Simplexvirus": 3
-        }
-    },
-    {
-        "cluster": "147",
-        "names": [
-            "non-structural glycoprotein",
-            "non-structural transmembrane glycoprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177197.1",
-                "name": "non-structural glycoprotein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177209.1",
-                "name": "non-structural glycoprotein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177243.1",
-                "name": "non-structural transmembrane glycoprotein",
-                "organism": "Adelaide River virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 641,
-        "length": 581,
-        "eff_nseq": 0.89,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alpharhabdovirinae": 3
-        },
-        "genera": {
-            "Ephemerovirus": 3
-        }
-    },
-    {
-        "cluster": "148",
-        "names": [
-            "matrix protein",
-            "glycoprotein D",
-            "envelope glycoprotein D"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009204555.1",
-                "name": "matrix protein",
-                "organism": "Fox fecal rhabdovirus"
-            },
-            {
-                "accession": "YP_009227224.1",
-                "name": "glycoprotein D",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230199.1",
-                "name": "envelope glycoprotein D",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 399,
-        "length": 379,
-        "eff_nseq": 0.87,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Rhabdoviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "unclassified Rhabdoviridae": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "149",
-        "names": [
-            "putative nucleoprotein",
-            "nonstrutural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177721.1",
-                "name": "putative nucleoprotein",
-                "organism": "Wuhan Mosquito Virus 8"
-            },
-            {
-                "accession": "YP_009182179.1",
-                "name": "putative nucleoprotein",
-                "organism": "Imjin River virus 1"
-            },
-            {
-                "accession": "YP_009480531.1",
-                "name": "nonstrutural protein",
-                "organism": "Arrabida virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 641,
-        "length": 635,
-        "eff_nseq": 0.73,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "unclassified ssRNA viruses": 1,
-            "Mivirus": 1,
-            "Phlebovirus": 1
-        },
-        "genera": {
-            "unclassified ssRNA negative-strand viruses": 1,
-            "Imjin mivirus": 1,
-            "unclassified Phlebovirus": 1
-        }
-    },
-    {
-        "cluster": "15",
-        "names": [
-            "hypothetical protein",
-            "putative structural protein",
-            "putative cell-to-cell movement protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176974.1",
-                "name": "putative cell-to-cell movement protein",
-                "organism": "Datura yellow vein nucleorhabdovirus"
-            },
-            {
-                "accession": "YP_009179229.1",
-                "name": "putative structural protein",
-                "organism": "Papaya meleira virus"
-            },
-            {
-                "accession": "YP_009182290.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186758.1",
-                "name": "ac78",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009204558.1",
-                "name": "alpha 2 protein",
-                "organism": "Fox fecal rhabdovirus"
-            },
-            {
-                "accession": "YP_009227122.1",
-                "name": "RNA-dependent RNA polymerase, partial",
-                "organism": "Tofla virus"
-            },
-            {
-                "accession": "YP_009230008.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009480344.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 8.0,
-        "alen": 3521,
-        "length": 986,
-        "eff_nseq": 3.22,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.72,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Ghabrivirales": 1,
-            "Rhabdoviridae": 2,
-            "Baculoviridae": 3,
-            "Spinareovirinae": 1,
-            "Orthonairovirus": 1
-        },
-        "genera": {
-            "Totiviridae": 1,
-            "Nucleorhabdovirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1,
-            "unclassified Nairovirus": 1,
-            "unclassified Rhabdoviridae": 1
-        }
-    },
-    {
-        "cluster": "150",
-        "names": [
-            "alpha 1 protein",
-            "glycoprotein M",
-            "envelope glycoprotein M UL10"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177244.1",
-                "name": "alpha 1 protein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009227243.1",
-                "name": "glycoprotein M",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230140.1",
-                "name": "envelope glycoprotein M UL10",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 451,
-        "length": 418,
-        "eff_nseq": 0.72,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "151",
-        "names": [
-            "NP1",
-            "NP1 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009215302.1",
-                "name": "NP1",
-                "organism": "Lagomorph bocaparvovirus 1"
-            },
-            {
-                "accession": "YP_009227292.1",
-                "name": "NP1",
-                "organism": "Rat bocavirus"
-            },
-            {
-                "accession": "YP_009229909.1",
-                "name": "NP1 protein",
-                "organism": "Bat bocavirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 216,
-        "length": 196,
-        "eff_nseq": 0.67,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Parvovirinae": 1,
-            "Bocaparvovirus": 2
-        },
-        "genera": {
-            "Bocaparvovirus": 1,
-            "Rodent bocaparvovirus 1": 1,
-            "unclassified Bocaparvovirus": 1
-        }
-    },
-    {
-        "cluster": "152",
-        "names": [
-            "structural protein",
-            "capsid portal protein",
-            "capsid portal protein UL6"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227239.1",
-                "name": "capsid portal protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230136.1",
-                "name": "capsid portal protein UL6",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009480338.1",
-                "name": "structural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 1195,
-        "length": 674,
-        "eff_nseq": 0.81,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Spinareovirinae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Fijivirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "153",
-        "names": [
-            "lef-4",
-            "late expression factor 4"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182284.1",
-                "name": "late expression factor 4",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186765.1",
-                "name": "lef-4",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229995.1",
-                "name": "lef-4",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 518,
-        "length": 450,
-        "eff_nseq": 0.64,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "154",
-        "names": [
-            "DNA-ligase",
-            "dna ligase",
-            "ligase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182307.1",
-                "name": "DNA-ligase",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186741.1",
-                "name": "dna ligase",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230017.1",
-                "name": "ligase",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 667,
-        "length": 563,
-        "eff_nseq": 0.68,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "155",
-        "names": [
-            "hypothetical protein",
-            "tlp-20",
-            "vp91"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182221.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186761.1",
-                "name": "tlp-20",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230002.1",
-                "name": "vp91",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 259,
-        "length": 224,
-        "eff_nseq": 0.95,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "156",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227228.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009227229.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009227230.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            }
-        ],
-        "count": 3.0,
-        "alen": 425,
-        "length": 378,
-        "eff_nseq": 0.99,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Simplexvirus": 3
-        }
-    },
-    {
-        "cluster": "157",
-        "names": [
-            "hypothetical protein",
-            "orf1629"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182248.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186693.1",
-                "name": "orf1629",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229950.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 566,
-        "length": 145,
-        "eff_nseq": 0.88,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.45,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "158",
-        "names": [
-            "N protein",
-            "nucleocapsid protein",
-            "hemagglutinin protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176972.1",
-                "name": "nucleocapsid protein",
-                "organism": "Datura yellow vein nucleorhabdovirus"
-            },
-            {
-                "accession": "YP_009177222.1",
-                "name": "N protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009177603.1",
-                "name": "hemagglutinin protein",
-                "organism": "Phocine morbillivirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 612,
-        "length": 461,
-        "eff_nseq": 1.16,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Betarhabdovirinae": 1,
-            "Rhabdoviridae": 1,
-            "Orthoparamyxovirinae": 1
-        },
-        "genera": {
-            "Cytorhabdovirus": 1,
-            "Nucleorhabdovirus": 1,
-            "Morbillivirus": 1
-        }
-    },
-    {
-        "cluster": "159",
-        "names": [
-            "phosphoprotein",
-            "tegument protein",
-            "tegument protein UL51"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177648.1",
-                "name": "phosphoprotein",
-                "organism": "Cocal virus"
-            },
-            {
-                "accession": "YP_009227284.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230186.1",
-                "name": "tegument protein UL51",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 272,
-        "length": 247,
-        "eff_nseq": 1.06,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Vesiculovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "16",
-        "names": [
-            "ORF4",
-            "alpha2 protein",
-            "single-stranded DNA binding protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177199.1",
-                "name": "alpha2 protein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177221.1",
-                "name": "ORF4",
-                "organism": "Suffolk virus"
-            },
-            {
-                "accession": "YP_009182267.1",
-                "name": "single-stranded DNA binding protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186704.1",
-                "name": "dbp-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186715.1",
-                "name": "ac34",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186721.1",
-                "name": "dbp-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229980.1",
-                "name": "dbp",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009480342.1",
-                "name": "minor core structural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 8.0,
-        "alen": 596,
-        "length": 326,
-        "eff_nseq": 3.51,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.72,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Mivirus": 1,
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 5,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Suffolk mivirus": 1,
-            "Ephemerovirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 3,
-            "Fijivirus": 1
-        }
-    },
-    {
-        "cluster": "160",
-        "names": [
-            "polyprotein",
-            "tegument protein",
-            "tegument protein UL14"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177608.1",
-                "name": "polyprotein",
-                "organism": "Tasmanian aquabirnavirus"
-            },
-            {
-                "accession": "YP_009227247.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230144.1",
-                "name": "tegument protein UL14",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 976,
-        "length": 285,
-        "eff_nseq": 0.92,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Aquabirnavirus": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "unclassified Aquabirnavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "161",
-        "names": [
-            "ODV-E27",
-            "odv-ec27",
-            "odv-e27"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182286.1",
-                "name": "ODV-E27",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186711.1",
-                "name": "odv-ec27",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229997.1",
-                "name": "odv-e27",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 313,
-        "length": 292,
-        "eff_nseq": 0.74,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "162",
-        "names": [
-            "39K",
-            "RNA dependent RNA polymerase",
-            "39k"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182165.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Botrytis ourmia-like virus"
-            },
-            {
-                "accession": "YP_009182249.1",
-                "name": "39K",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229949.1",
-                "name": "39k",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 725,
-        "length": 501,
-        "eff_nseq": 1.03,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 2,
-            "Botoulivirus": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Botrytis botoulivirus": 1
-        }
-    },
-    {
-        "cluster": "163",
-        "names": [
-            "hypothetical protein",
-            "gamma protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177214.1",
-                "name": "gamma protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009182288.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229999.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 369,
-        "length": 336,
-        "eff_nseq": 0.86,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "164",
-        "names": [
-            "hypothetical protein",
-            "ac81"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182220.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186760.1",
-                "name": "ac81",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230006.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 238,
-        "length": 203,
-        "eff_nseq": 0.53,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "165",
-        "names": [
-            "tegument protein",
-            "tegument protein UL16",
-            "membrane protein UL43"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227249.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230145.1",
-                "name": "tegument protein UL16",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230175.1",
-                "name": "membrane protein UL43",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 455,
-        "length": 364,
-        "eff_nseq": 0.84,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Simplexvirus": 3
-        }
-    },
-    {
-        "cluster": "166",
-        "names": [
-            "granulin",
-            "polyhedrin"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182199.1",
-                "name": "granulin",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186692.1",
-                "name": "polyhedrin",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229920.1",
-                "name": "granulin",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 249,
-        "length": 248,
-        "eff_nseq": 0.48,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "167",
-        "names": [
-            "pif-3",
-            "per os infectivity factor 3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182228.1",
-                "name": "per os infectivity factor 3",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186791.1",
-                "name": "pif-3",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229961.1",
-                "name": "pif-3",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 208,
-        "length": 196,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "168",
-        "names": [
-            "late expression factor 5",
-            "lef-5",
-            "38k"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182275.1",
-                "name": "late expression factor 5",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186773.1",
-                "name": "lef-5",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229988.1",
-                "name": "38k",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 291,
-        "length": 250,
-        "eff_nseq": 0.55,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "169",
-        "names": [
-            "matrix protein",
-            "ORF3'"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177601.1",
-                "name": "matrix protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009179209.1",
-                "name": "matrix protein",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009221997.1",
-                "name": "ORF3'",
-                "organism": "Kafue kinda chacma baboon virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 369,
-        "length": 338,
-        "eff_nseq": 0.82,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.78,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Orthoparamyxovirinae": 1,
-            "Respirovirus": 1,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Morbillivirus": 1,
-            "Caprine respirovirus 3": 1,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "17",
-        "names": [
-            "triple gene block protein 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186835.1",
-                "name": "triple gene block protein 1",
-                "organism": "Actinidia virus X"
-            },
-            {
-                "accession": "YP_009204562.1",
-                "name": "triple gene block protein 1",
-                "organism": "Asian prunus virus 2"
-            },
-            {
-                "accession": "YP_009215375.1",
-                "name": "triple gene block protein 1",
-                "organism": "Asian prunus virus 3"
-            },
-            {
-                "accession": "YP_009224929.1",
-                "name": "triple gene block protein 1",
-                "organism": "Elderberry carlavirus A"
-            },
-            {
-                "accession": "YP_009224935.1",
-                "name": "triple gene block protein 1",
-                "organism": "Elderberry carlavirus B"
-            },
-            {
-                "accession": "YP_009224941.1",
-                "name": "triple gene block protein 1",
-                "organism": "Elderberry carlavirus C"
-            },
-            {
-                "accession": "YP_009224947.1",
-                "name": "triple gene block protein 1",
-                "organism": "Elderberry carlavirus D"
-            },
-            {
-                "accession": "YP_009224953.1",
-                "name": "triple gene block protein 1",
-                "organism": "Elderberry carlavirus E"
-            }
-        ],
-        "count": 8.0,
-        "alen": 252,
-        "length": 235,
-        "eff_nseq": 0.97,
-        "mean_entropy": 0.591,
-        "total_entropy": 4.73,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaflexiviridae": 1,
-            "Foveavirus": 1,
-            "Quinvirinae": 4,
-            "Carlavirus": 2
-        },
-        "genera": {
-            "Potexvirus": 1,
-            "unclassified Foveavirus": 1,
-            "Foveavirus": 1,
-            "Carlavirus": 3,
-            "unclassified Carlavirus": 2
-        }
-    },
-    {
-        "cluster": "170",
-        "names": [
-            "phosphoprotein",
-            "V protein",
-            "V2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177598.1",
-                "name": "phosphoprotein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009177599.1",
-                "name": "V protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009226623.1",
-                "name": "V2",
-                "organism": "Turnip leaf roll virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 510,
-        "length": 337,
-        "eff_nseq": 0.71,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Orthoparamyxovirinae": 2,
-            "Geminiviridae": 1
-        },
-        "genera": {
-            "Morbillivirus": 2,
-            "Turncurtovirus": 1
-        }
-    },
-    {
-        "cluster": "171",
-        "names": [
-            "hypothetical protein",
-            "pif-6",
-            "lef-3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182298.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186751.1",
-                "name": "pif-6",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230022.1",
-                "name": "lef-3",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 139,
-        "length": 128,
-        "eff_nseq": 0.63,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "172",
-        "names": [
-            "hypothetical protein",
-            "ac112"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182293.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186784.1",
-                "name": "ac112",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230027.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 339,
-        "length": 180,
-        "eff_nseq": 0.78,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "173",
-        "names": [
-            "pif-5",
-            "ODV-E56, per os infectivity factor 6"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182210.1",
-                "name": "ODV-E56, per os infectivity factor 6",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186697.1",
-                "name": "pif-5",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229932.1",
-                "name": "pif-5",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 393,
-        "length": 364,
-        "eff_nseq": 0.57,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "174",
-        "names": [
-            "thymidine kinase",
-            "thymidine kinase, partial"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207083.1",
-                "name": "thymidine kinase, partial",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227256.1",
-                "name": "thymidine kinase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230154.1",
-                "name": "thymidine kinase",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 376,
-        "length": 330,
-        "eff_nseq": 0.79,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "175",
-        "names": [
-            "DNA cleavage/packaging protein",
-            "DNA packaging protein",
-            "DNA packaging protein UL33"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207094.1",
-                "name": "DNA cleavage/packaging protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227266.1",
-                "name": "DNA packaging protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230163.1",
-                "name": "DNA packaging protein UL33",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 161,
-        "length": 128,
-        "eff_nseq": 0.69,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "176",
-        "names": [
-            "E6",
-            "nucleocapsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177725.1",
-                "name": "E6",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182324.1",
-                "name": "E6",
-                "organism": "Rattus norvegicus papillomavirus 3"
-            },
-            {
-                "accession": "YP_009227120.1",
-                "name": "nucleocapsid protein",
-                "organism": "Tofla virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 487,
-        "length": 327,
-        "eff_nseq": 1.03,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Firstpapillomavirinae": 2,
-            "Orthonairovirus": 1
-        },
-        "genera": {
-            "Rhopapillomavirus": 1,
-            "Iotapapillomavirus": 1,
-            "unclassified Nairovirus": 1
-        }
-    },
-    {
-        "cluster": "177",
-        "names": [
-            "pre-coat protein",
-            "AV2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177709.1",
-                "name": "pre-coat protein",
-                "organism": "Andrographis yellow vein leaf curl virus"
-            },
-            {
-                "accession": "YP_009216259.1",
-                "name": "pre-coat protein",
-                "organism": "Okra leaf curl Oman virus"
-            },
-            {
-                "accession": "YP_009216582.1",
-                "name": "AV2",
-                "organism": "Pepper yellow leaf curl Thailand virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 122,
-        "length": 122,
-        "eff_nseq": 0.5,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.76,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Geminiviridae": 3
-        },
-        "genera": {
-            "Begomovirus": 3
-        }
-    },
-    {
-        "cluster": "178",
-        "names": [
-            "hypothetical protein",
-            "odv-e66"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182230.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182236.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229959.1",
-                "name": "odv-e66",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 404,
-        "length": 205,
-        "eff_nseq": 0.78,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "179",
-        "names": [
-            "odv-ec43",
-            "ODV-EC43"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182247.1",
-                "name": "ODV-EC43",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186780.1",
-                "name": "odv-ec43",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229951.1",
-                "name": "odv-ec43",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 396,
-        "length": 348,
-        "eff_nseq": 0.59,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "18",
-        "names": [
-            "RNA dependent RNA polymerase",
-            "ac108",
-            "replicase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182160.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Botrytis cinerea mitovirus 2"
-            },
-            {
-                "accession": "YP_009182161.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Botrytis cinerea mitovirus 3"
-            },
-            {
-                "accession": "YP_009182162.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Grapevine associated narnavirus-1"
-            },
-            {
-                "accession": "YP_009182163.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Botrytis cinerea mitovirus 4"
-            },
-            {
-                "accession": "YP_009182164.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Sclerotinia sclerotiorum mitovirus 3"
-            },
-            {
-                "accession": "YP_009186781.1",
-                "name": "ac108",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009204553.1",
-                "name": "nucleocapsid protein",
-                "organism": "Fox fecal rhabdovirus"
-            },
-            {
-                "accession": "YP_009208148.1",
-                "name": "replicase",
-                "organism": "Escherichia virus FI"
-            }
-        ],
-        "count": 8.0,
-        "alen": 855,
-        "length": 706,
-        "eff_nseq": 2.82,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.72,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Mitovirus": 4,
-            "Narnavirus": 1,
-            "Baculoviridae": 1,
-            "Leviviridae": 1,
-            "Rhabdoviridae": 1
-        },
-        "genera": {
-            "unclassified Mitovirus": 4,
-            "unclassified Narnavirus": 1,
-            "Alphabaculovirus": 1,
-            "Allolevivirus": 1,
-            "unclassified Rhabdoviridae": 1
-        }
-    },
-    {
-        "cluster": "180",
-        "names": [
-            "vp1054",
-            "VP1054"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182322.1",
-                "name": "VP1054",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186732.1",
-                "name": "vp1054",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230034.1",
-                "name": "vp1054",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 399,
-        "length": 332,
-        "eff_nseq": 0.59,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "181",
-        "names": [
-            "tegument protein",
-            "ORF4' protein",
-            "virion protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009221998.1",
-                "name": "ORF4' protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009227220.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230197.1",
-                "name": "virion protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 362,
-        "length": 261,
-        "eff_nseq": 0.88,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 2,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Simplexvirus": 2,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "182",
-        "names": [
-            "per os infectivity factor 1",
-            "pif-1",
-            "lef-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182261.1",
-                "name": "per os infectivity factor 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186820.1",
-                "name": "pif-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229974.1",
-                "name": "lef-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 573,
-        "length": 536,
-        "eff_nseq": 0.59,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "183",
-        "names": [
-            "hypothetical protein",
-            "polyhedron envelope protein 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182212.1",
-                "name": "polyhedron envelope protein 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182218.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229934.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 213,
-        "length": 190,
-        "eff_nseq": 0.88,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "184",
-        "names": [
-            "alpha 1 protein",
-            "envelope protein",
-            "integral membrane protein UL20"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009204557.1",
-                "name": "alpha 1 protein",
-                "organism": "Fox fecal rhabdovirus"
-            },
-            {
-                "accession": "YP_009227253.1",
-                "name": "envelope protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230151.1",
-                "name": "integral membrane protein UL20",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 223,
-        "length": 222,
-        "eff_nseq": 0.83,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Rhabdoviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "unclassified Rhabdoviridae": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "185",
-        "names": [
-            "hypothetical protein",
-            "3A"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182216.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009220472.1",
-                "name": "3A",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009229939.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 477,
-        "length": 346,
-        "eff_nseq": 0.94,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 2,
-            "Hepatovirus": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "unclassified Hepatovirus": 1
-        }
-    },
-    {
-        "cluster": "186",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182304.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182305.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182306.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 525,
-        "length": 361,
-        "eff_nseq": 0.77,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "187",
-        "names": [
-            "hypothetical protein",
-            "ac106"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182244.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186788.1",
-                "name": "ac106",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229954.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 241,
-        "length": 226,
-        "eff_nseq": 0.62,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "188",
-        "names": [
-            "late expression factor 1",
-            "lef-1",
-            "pif-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182260.1",
-                "name": "late expression factor 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186812.1",
-                "name": "lef-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229973.1",
-                "name": "pif-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 271,
-        "length": 236,
-        "eff_nseq": 0.61,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "189",
-        "names": [
-            "deoxyuridine triphosphatase",
-            "GP3 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009222001.1",
-                "name": "GP3 protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009227283.1",
-                "name": "deoxyuridine triphosphatase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230185.1",
-                "name": "deoxyuridine triphosphatase",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 377,
-        "length": 358,
-        "eff_nseq": 0.89,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Simplexvirus": 2,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "19",
-        "names": [
-            "nucleocapsid protein",
-            "hypothetical protein",
-            "nucleoprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182232.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009194643.1",
-                "name": "nucleocapsid protein",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199247.1",
-                "name": "nucleoprotein",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199613.1",
-                "name": "nucleocapsid protein",
-                "organism": "BtMr-AlphaCoV/SAX2011"
-            },
-            {
-                "accession": "YP_009199794.1",
-                "name": "nucleocapsid protein",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009200739.1",
-                "name": "nucleocapsid protein",
-                "organism": "BtRf-AlphaCoV/YN2012"
-            },
-            {
-                "accession": "YP_009201734.1",
-                "name": "nucleocapsid protein",
-                "organism": "BtNv-AlphaCoV/SC2013"
-            },
-            {
-                "accession": "YP_009229987.1",
-                "name": "p6.9a",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 8.0,
-        "alen": 478,
-        "length": 371,
-        "eff_nseq": 1.54,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.72,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphacoronavirus": 2,
-            "Rhinacovirus": 1,
-            "Decacovirus": 1,
-            "Nyctacovirus": 1,
-            "Myotacovirus": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1,
-            "unclassified Rhinacovirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
-            "Myotis ricketti alphacoronavirus Sax-2011": 1
-        }
-    },
-    {
-        "cluster": "190",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182309.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230014.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230130.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 104,
-        "length": 99,
-        "eff_nseq": 0.79,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "191",
-        "names": [
-            "membrane-associated protein",
-            "nuclear protein",
-            "nuclear protein UL24"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207084.1",
-                "name": "membrane-associated protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227257.1",
-                "name": "nuclear protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230155.1",
-                "name": "nuclear protein UL24",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 3.0,
-        "alen": 317,
-        "length": 258,
-        "eff_nseq": 0.74,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.78,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "192",
-        "names": [
-            "coat protein",
-            "putative coat protein",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009218535.1",
-                "name": "hypothetical protein",
-                "organism": "Parabacteroides phage YZ-2015a"
-            },
-            {
-                "accession": "YP_009220368.1",
-                "name": "putative coat protein",
-                "organism": "Colombian potato soil-borne virus"
-            },
-            {
-                "accession": "YP_009220369.1",
-                "name": "coat protein",
-                "organism": "Colombian potato soil-borne virus"
-            }
-        ],
-        "count": 3.0,
-        "alen": 862,
-        "length": 862,
-        "eff_nseq": 0.72,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.77,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Virgaviridae": 2,
-            "Microviridae": 1
-        },
-        "genera": {
-            "Pomovirus": 2,
-            "unclassified Microviridae": 1
-        }
-    },
-    {
-        "cluster": "193",
-        "names": [
-            "RNA polymerase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_008999611.1",
-                "name": "RNA polymerase",
-                "organism": "Eggplant mottled crinkle virus"
-            },
-            {
-                "accession": "YP_008999612.1",
-                "name": "RNA polymerase",
-                "organism": "Eggplant mottled crinkle virus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 818,
-        "length": 818,
-        "eff_nseq": 0.5,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Procedovirinae": 2
-        },
-        "genera": {
-            "Tombusvirus": 2
-        }
-    },
-    {
-        "cluster": "194",
-        "names": [
-            "multifunctional expression regulator ICP27",
-            "UL54 multifunctional expression regulator"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227287.1",
-                "name": "multifunctional expression regulator ICP27",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230189.1",
-                "name": "UL54 multifunctional expression regulator",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 525,
-        "length": 525,
-        "eff_nseq": 0.57,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "195",
-        "names": [
-            "tegument protein VP11/12",
-            "UL46 tegument protein VP11/12"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227278.1",
-                "name": "tegument protein VP11/12",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230179.1",
-                "name": "UL46 tegument protein VP11/12",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 783,
-        "length": 783,
-        "eff_nseq": 0.61,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "196",
-        "names": [
-            "DNA polymerase processivity subunit",
-            "DNA polymerase processivity factor"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227275.1",
-                "name": "DNA polymerase processivity subunit",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230174.1",
-                "name": "DNA polymerase processivity factor",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 496,
-        "length": 496,
-        "eff_nseq": 0.62,
-        "mean_entropy": 0.593,
-        "total_entropy": 1.19,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "197",
-        "names": [
-            "glycoprotein",
-            "orf112"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176976.1",
-                "name": "glycoprotein",
-                "organism": "Datura yellow vein nucleorhabdovirus"
-            },
-            {
-                "accession": "YP_009186803.1",
-                "name": "orf112",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 631,
-        "length": 631,
-        "eff_nseq": 0.72,
-        "mean_entropy": 0.593,
-        "total_entropy": 1.19,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Rhabdoviridae": 1,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "Nucleorhabdovirus": 1,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "198",
-        "names": [
-            "replication-associated protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009226561.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular virus 1"
-            },
-            {
-                "accession": "YP_009226565.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular virus 3"
-            }
-        ],
-        "count": 2.0,
-        "alen": 323,
-        "length": 323,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.593,
-        "total_entropy": 1.19,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "unclassified DNA viruses": 2
-        },
-        "genera": {
-            "unclassified ssDNA viruses": 2
-        }
-    },
-    {
-        "cluster": "199",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182319.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230032.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 337,
-        "length": 337,
-        "eff_nseq": 0.64,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "2",
-        "names": [
-            "RNA dependent RNA polymerase",
-            "polyprotein",
-            "RNA-dependent RNA polymeras"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179230.1",
-                "name": "RNA-dependent RNA polymeras",
-                "organism": "Papaya meleira virus"
-            },
-            {
-                "accession": "YP_009182174.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 1"
-            },
-            {
-                "accession": "YP_009182176.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 2"
-            },
-            {
-                "accession": "YP_009182181.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 3"
-            },
-            {
-                "accession": "YP_009182188.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 5"
-            },
-            {
-                "accession": "YP_009182190.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 6"
-            },
-            {
-                "accession": "YP_009182195.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Red clover powdery mildew-associated totivirus 7"
-            },
-            {
-                "accession": "YP_009182198.1",
-                "name": "polyprotein",
-                "organism": "Red clover powdery mildew-associated totivirus 9"
-            },
-            {
-                "accession": "YP_009182332.1",
-                "name": "127 kDa protein",
-                "organism": "Penicillium janczewskii chrysovirus 1"
-            },
-            {
-                "accession": "YP_009207096.1",
-                "name": "basic phosphorylated capsid protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009209482.1",
-                "name": "polyprotein",
-                "organism": "Thelephora terrestris virus 1"
-            },
-            {
-                "accession": "YP_009225665.1",
-                "name": "putative RNA-dependent RNA polymerase",
-                "organism": "Panax notoginseng virus A"
-            },
-            {
-                "accession": "YP_009227124.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Rosellinia necatrix megabirnavirus 2-W8"
-            }
-        ],
-        "count": 13.0,
-        "alen": 2178,
-        "length": 961,
-        "eff_nseq": 4.26,
-        "mean_entropy": 0.59,
-        "total_entropy": 7.67,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Ghabrivirales": 10,
-            "Chrysoviridae": 1,
-            "Alphaherpesvirinae": 1,
-            "Megabirnavirus": 1
-        },
-        "genera": {
-            "Totiviridae": 10,
-            "Betachrysovirus": 1,
-            "Scutavirus": 1,
-            "unclassified Megabirnavirus": 1
-        }
-    },
-    {
-        "cluster": "20",
-        "names": [
-            "replication-associated protein",
-            "hypothetical protein",
-            "ORF2a' protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182233.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009221996.1",
-                "name": "ORF2a' protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009226563.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular virus 2"
-            },
-            {
-                "accession": "YP_009226567.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular virus 4"
-            },
-            {
-                "accession": "YP_009226569.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular genome 1"
-            },
-            {
-                "accession": "YP_009226571.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular genome 3"
-            },
-            {
-                "accession": "YP_009226572.1",
-                "name": "replication-associated protein",
-                "organism": "Ctenophore-associated circular genome 4"
-            },
-            {
-                "accession": "YP_009230209.1",
-                "name": "replication protein",
-                "organism": "Bhindi yellow vein alphasatellite"
-            }
-        ],
-        "count": 8.0,
-        "alen": 354,
-        "length": 291,
-        "eff_nseq": 2.25,
-        "mean_entropy": 0.591,
-        "total_entropy": 4.73,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 1,
-            "Kaftartevirus": 1,
-            "unclassified DNA viruses": 2,
-            "DNA satellites": 3,
-            "Geminialphasatellitinae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 1,
-            "Thetaarterivirus kafuba": 1,
-            "unclassified ssDNA viruses": 2,
-            "Single stranded DNA satellites": 3,
-            "unclassified Begomovirus-associated alphasatellites": 1
-        }
-    },
-    {
-        "cluster": "200",
-        "names": [
-            "tegument host shutoff protein",
-            "UL41 tegument host shutoff protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227274.1",
-                "name": "tegument host shutoff protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230172.1",
-                "name": "UL41 tegument host shutoff protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 528,
-        "length": 528,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "201",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182235.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229941.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 82,
-        "length": 82,
-        "eff_nseq": 0.64,
-        "mean_entropy": 0.692,
-        "total_entropy": 1.38,
-        "mean_positional_relative_entropy": 0.62,
-        "kullback_leibler_divergence": 0.08,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "202",
-        "names": [
-            "glycoprotein C",
-            "envelope glycoprotein C"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227276.1",
-                "name": "glycoprotein C",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230177.1",
-                "name": "envelope glycoprotein C",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 465,
-        "length": 465,
-        "eff_nseq": 0.64,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "203",
-        "names": [
-            "desmoplakin",
-            "polymerase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182296.1",
-                "name": "desmoplakin",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230025.1",
-                "name": "polymerase",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 637,
-        "length": 637,
-        "eff_nseq": 0.67,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "204",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182227.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229962.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 239,
-        "length": 239,
-        "eff_nseq": 0.6,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "205",
-        "names": [
-            "helicase-primase subunit",
-            "helicase/primase complex associated protein UL8"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227241.1",
-                "name": "helicase-primase subunit",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230138.1",
-                "name": "helicase/primase complex associated protein UL8",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 758,
-        "length": 758,
-        "eff_nseq": 0.59,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "206",
-        "names": [
-            "ODV-E66",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182229.1",
-                "name": "ODV-E66",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229960.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 774,
-        "length": 774,
-        "eff_nseq": 0.46,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "207",
-        "names": [
-            "tegument protein",
-            "UL21 tegument protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227254.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230152.1",
-                "name": "UL21 tegument protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 543,
-        "length": 543,
-        "eff_nseq": 0.59,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "208",
-        "names": [
-            "E1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177727.1",
-                "name": "E1",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182326.1",
-                "name": "E1",
-                "organism": "Rattus norvegicus papillomavirus 3"
-            }
-        ],
-        "count": 2.0,
-        "alen": 629,
-        "length": 629,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.586,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Firstpapillomavirinae": 2
-        },
-        "genera": {
-            "Rhopapillomavirus": 1,
-            "Iotapapillomavirus": 1
-        }
-    },
-    {
-        "cluster": "209",
-        "names": [
-            "minor structural protein",
-            "major structural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175069.1",
-                "name": "minor structural protein",
-                "organism": "Ungulate tetraparvovirus 1"
-            },
-            {
-                "accession": "YP_009175070.1",
-                "name": "major structural protein",
-                "organism": "Ungulate tetraparvovirus 1"
-            }
-        ],
-        "count": 2.0,
-        "alen": 931,
-        "length": 931,
-        "eff_nseq": 0.47,
-        "mean_entropy": 0.586,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.0,
-        "families": {
-            "Parvovirinae": 2
-        },
-        "genera": {
-            "Tetraparvovirus": 2
-        }
-    },
-    {
-        "cluster": "21",
-        "names": [
-            "coat protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186838.1",
-                "name": "coat protein",
-                "organism": "Actinidia virus X"
-            },
-            {
-                "accession": "YP_009204565.1",
-                "name": "coat protein",
-                "organism": "Asian prunus virus 2"
-            },
-            {
-                "accession": "YP_009215378.1",
-                "name": "coat protein",
-                "organism": "Asian prunus virus 3"
-            },
-            {
-                "accession": "YP_009224932.1",
-                "name": "coat protein",
-                "organism": "Elderberry carlavirus A"
-            },
-            {
-                "accession": "YP_009224938.1",
-                "name": "coat protein",
-                "organism": "Elderberry carlavirus B"
-            },
-            {
-                "accession": "YP_009224944.1",
-                "name": "coat protein",
-                "organism": "Elderberry carlavirus C"
-            },
-            {
-                "accession": "YP_009224950.1",
-                "name": "coat protein",
-                "organism": "Elderberry carlavirus D"
-            },
-            {
-                "accession": "YP_009224956.1",
-                "name": "coat protein",
-                "organism": "Elderberry carlavirus E"
-            }
-        ],
-        "count": 8.0,
-        "alen": 415,
-        "length": 306,
-        "eff_nseq": 1.07,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.72,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaflexiviridae": 1,
-            "Foveavirus": 1,
-            "Quinvirinae": 4,
-            "Carlavirus": 2
-        },
-        "genera": {
-            "Potexvirus": 1,
-            "unclassified Foveavirus": 1,
-            "Foveavirus": 1,
-            "Carlavirus": 3,
-            "unclassified Carlavirus": 2
-        }
-    },
-    {
-        "cluster": "210",
-        "names": [
-            "DNA packaging terminase subunit 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227248.2",
-                "name": "DNA packaging terminase subunit 1",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230148.1",
-                "name": "DNA packaging terminase subunit 1",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 735,
-        "length": 735,
-        "eff_nseq": 0.56,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "211",
-        "names": [
-            "glycoprotein K",
-            "envelope glycoprotein K"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227286.1",
-                "name": "glycoprotein K",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230188.1",
-                "name": "envelope glycoprotein K",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 342,
-        "length": 342,
-        "eff_nseq": 0.55,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "212",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009226562.1",
-                "name": "hypothetical protein",
-                "organism": "Ctenophore-associated circular virus 1"
-            },
-            {
-                "accession": "YP_009226566.1",
-                "name": "hypothetical protein",
-                "organism": "Ctenophore-associated circular virus 3"
-            }
-        ],
-        "count": 2.0,
-        "alen": 240,
-        "length": 240,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified DNA viruses": 2
-        },
-        "genera": {
-            "unclassified ssDNA viruses": 2
-        }
-    },
-    {
-        "cluster": "213",
-        "names": [
-            "A1-protein",
-            "major coat protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009208146.1",
-                "name": "A1-protein",
-                "organism": "Escherichia virus FI"
-            },
-            {
-                "accession": "YP_009208147.1",
-                "name": "major coat protein",
-                "organism": "Escherichia virus FI"
-            }
-        ],
-        "count": 2.0,
-        "alen": 332,
-        "length": 332,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Leviviridae": 2
-        },
-        "genera": {
-            "Allolevivirus": 2
-        }
-    },
-    {
-        "cluster": "214",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182203.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229923.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 213,
-        "length": 213,
-        "eff_nseq": 0.57,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "215",
-        "names": [
-            "nuclear protein",
-            "nuclear protein UL55"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227288.1",
-                "name": "nuclear protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230190.1",
-                "name": "nuclear protein UL55",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 185,
-        "length": 185,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "216",
-        "names": [
-            "polyhedron envelope/P10 fusion protein",
-            "pep/p10"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182214.1",
-                "name": "polyhedron envelope/P10 fusion protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229936.1",
-                "name": "pep/p10",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 357,
-        "length": 357,
-        "eff_nseq": 0.52,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "217",
-        "names": [
-            "small capsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227268.1",
-                "name": "small capsid protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230165.1",
-                "name": "small capsid protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 135,
-        "length": 135,
-        "eff_nseq": 0.57,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "218",
-        "names": [
-            "capsid triplex subunit 2",
-            "capsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227251.1",
-                "name": "capsid triplex subunit 2",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230149.1",
-                "name": "capsid protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 318,
-        "length": 318,
-        "eff_nseq": 0.46,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "219",
-        "names": [
-            "capsid triplex subunit 1",
-            "UL38 capsid triplex subunit 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227271.1",
-                "name": "capsid triplex subunit 1",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230168.1",
-                "name": "UL38 capsid triplex subunit 1",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 501,
-        "length": 501,
-        "eff_nseq": 0.54,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "22",
-        "names": [
-            "replication enhancement protein",
-            "replication enhancer protein",
-            "replicase-associated protein"
-        ],
-        "entries": [
-            {
-                "accession": "NP_835273.1",
-                "name": "replicase-associated protein",
-                "organism": "Melon chlorotic leaf curl virus-"
-            },
-            {
-                "accession": "YP_009175076.1",
-                "name": "replication enhancement protein",
-                "organism": "Melochia mosaic virus"
-            },
-            {
-                "accession": "YP_009175083.1",
-                "name": "replication enhancement protein",
-                "organism": "Melochia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009177711.1",
-                "name": "replication enhancer protein",
-                "organism": "Andrographis yellow vein leaf curl virus"
-            },
-            {
-                "accession": "YP_009216261.1",
-                "name": "replication enhancement protein",
-                "organism": "Okra leaf curl Oman virus"
-            },
-            {
-                "accession": "YP_009216584.1",
-                "name": "AC3",
-                "organism": "Pepper yellow leaf curl Thailand virus"
-            },
-            {
-                "accession": "YP_009226415.1",
-                "name": "replication enhancer protein",
-                "organism": "Pavonia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009226625.1",
-                "name": "C3",
-                "organism": "Turnip leaf roll virus"
-            }
-        ],
-        "count": 8.0,
-        "alen": 145,
-        "length": 134,
-        "eff_nseq": 0.73,
-        "mean_entropy": 0.591,
-        "total_entropy": 4.73,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Geminiviridae": 8
-        },
-        "genera": {
-            "Begomovirus": 7,
-            "Turncurtovirus": 1
-        }
-    },
-    {
-        "cluster": "220",
-        "names": [
-            "DNA pilot protein VP2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009218537.1",
-                "name": "DNA pilot protein VP2",
-                "organism": "Parabacteroides phage YZ-2015a"
-            },
-            {
-                "accession": "YP_009218804.1",
-                "name": "DNA pilot protein VP2",
-                "organism": "Parabacteroides phage YZ-2015b"
-            }
-        ],
-        "count": 2.0,
-        "alen": 294,
-        "length": 294,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Microviridae": 2
-        },
-        "genera": {
-            "unclassified Microviridae": 2
-        }
-    },
-    {
-        "cluster": "221",
-        "names": [
-            "ac17",
-            "p22.2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186808.1",
-                "name": "ac17",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229945.1",
-                "name": "p22.2",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 247,
-        "length": 247,
-        "eff_nseq": 0.68,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "222",
-        "names": [
-            "hypothetical protein",
-            "nrk1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182209.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186785.1",
-                "name": "nrk1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 359,
-        "length": 359,
-        "eff_nseq": 0.61,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 1,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "223",
-        "names": [
-            "uracil-DNA glycosylase",
-            "uracil-DNA glycosylase UL2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227237.1",
-                "name": "uracil-DNA glycosylase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230132.1",
-                "name": "uracil-DNA glycosylase UL2",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 319,
-        "length": 319,
-        "eff_nseq": 0.5,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "224",
-        "names": [
-            "p48/p45",
-            "p45/p48"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186777.1",
-                "name": "p48/p45",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229984.1",
-                "name": "p45/p48",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 413,
-        "length": 413,
-        "eff_nseq": 0.55,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "225",
-        "names": [
-            "E7"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177726.1",
-                "name": "E7",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182325.1",
-                "name": "E7",
-                "organism": "Rattus norvegicus papillomavirus 3"
-            }
-        ],
-        "count": 2.0,
-        "alen": 101,
-        "length": 101,
-        "eff_nseq": 0.58,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Firstpapillomavirinae": 2
-        },
-        "genera": {
-            "Rhopapillomavirus": 1,
-            "Iotapapillomavirus": 1
-        }
-    },
-    {
-        "cluster": "226",
-        "names": [
-            "capsid maturation protease",
-            "virion scaffolding protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207086.1",
-                "name": "capsid maturation protease",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009207087.1",
-                "name": "virion scaffolding protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 549,
-        "length": 549,
-        "eff_nseq": 0.51,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Scutavirus": 2
-        }
-    },
-    {
-        "cluster": "227",
-        "names": [
-            "hypothetical protein",
-            "pk-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182200.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229921.1",
-                "name": "pk-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 159,
-        "length": 159,
-        "eff_nseq": 0.67,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "228",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182242.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229956.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 67,
-        "length": 67,
-        "eff_nseq": 0.9,
-        "mean_entropy": 0.84,
-        "total_entropy": 1.68,
-        "mean_positional_relative_entropy": 0.78,
-        "kullback_leibler_divergence": 0.07,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "229",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182202.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182257.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 87,
-        "length": 87,
-        "eff_nseq": 0.71,
-        "mean_entropy": 0.654,
-        "total_entropy": 1.31,
-        "mean_positional_relative_entropy": 0.58,
-        "kullback_leibler_divergence": 0.1,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "23",
-        "names": [
-            "triple gene block protein 3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186837.1",
-                "name": "triple gene block protein 3",
-                "organism": "Actinidia virus X"
-            },
-            {
-                "accession": "YP_009204564.1",
-                "name": "triple gene block protein 3",
-                "organism": "Asian prunus virus 2"
-            },
-            {
-                "accession": "YP_009215377.1",
-                "name": "triple gene block protein 3",
-                "organism": "Asian prunus virus 3"
-            },
-            {
-                "accession": "YP_009224931.1",
-                "name": "triple gene block protein 3",
-                "organism": "Elderberry carlavirus A"
-            },
-            {
-                "accession": "YP_009224937.1",
-                "name": "triple gene block protein 3",
-                "organism": "Elderberry carlavirus B"
-            },
-            {
-                "accession": "YP_009224943.1",
-                "name": "triple gene block protein 3",
-                "organism": "Elderberry carlavirus C"
-            },
-            {
-                "accession": "YP_009224949.1",
-                "name": "triple gene block protein 3",
-                "organism": "Elderberry carlavirus D"
-            },
-            {
-                "accession": "YP_009224955.1",
-                "name": "triple gene block protein 3",
-                "organism": "Elderberry carlavirus E"
-            }
-        ],
-        "count": 8.0,
-        "alen": 94,
-        "length": 71,
-        "eff_nseq": 2.18,
-        "mean_entropy": 0.794,
-        "total_entropy": 6.35,
-        "mean_positional_relative_entropy": 0.74,
-        "kullback_leibler_divergence": 0.07,
-        "families": {
-            "Alphaflexiviridae": 1,
-            "Foveavirus": 1,
-            "Quinvirinae": 4,
-            "Carlavirus": 2
-        },
-        "genera": {
-            "Potexvirus": 1,
-            "unclassified Foveavirus": 1,
-            "Foveavirus": 1,
-            "Carlavirus": 3,
-            "unclassified Carlavirus": 2
-        }
-    },
-    {
-        "cluster": "230",
-        "names": [
-            "coat protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182166.1",
-                "name": "coat protein",
-                "organism": "Ustilaginoidea virens RNA virus 5"
-            },
-            {
-                "accession": "YP_009212847.1",
-                "name": "coat protein",
-                "organism": "Penicillium aurantiogriseum totivirus 1"
-            }
-        ],
-        "count": 2.0,
-        "alen": 786,
-        "length": 786,
-        "eff_nseq": 0.61,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Victorivirus": 1,
-            "Ghabrivirales": 1
-        },
-        "genera": {
-            "unclassified Victorivirus": 1,
-            "Totiviridae": 1
-        }
-    },
-    {
-        "cluster": "231",
-        "names": [
-            "alkaline exonuclease",
-            "deoxyribonuclease"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227245.1",
-                "name": "alkaline exonuclease",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230142.1",
-                "name": "deoxyribonuclease",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 606,
-        "length": 606,
-        "eff_nseq": 0.56,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "232",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182300.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230021.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 173,
-        "length": 173,
-        "eff_nseq": 0.57,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.06,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "233",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182254.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009229968.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 233,
-        "length": 233,
-        "eff_nseq": 0.72,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "234",
-        "names": [
-            "replication protein VP4"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009218538.1",
-                "name": "replication protein VP4",
-                "organism": "Parabacteroides phage YZ-2015a"
-            },
-            {
-                "accession": "YP_009218805.1",
-                "name": "replication protein VP4",
-                "organism": "Parabacteroides phage YZ-2015b"
-            }
-        ],
-        "count": 2.0,
-        "alen": 287,
-        "length": 287,
-        "eff_nseq": 0.42,
-        "mean_entropy": 0.59,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Microviridae": 2
-        },
-        "genera": {
-            "unclassified Microviridae": 2
-        }
-    },
-    {
-        "cluster": "235",
-        "names": [
-            "desmoplakin",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186753.1",
-                "name": "desmoplakin",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229917.1",
-                "name": "hypothetical protein",
-                "organism": "Blackberry virus F"
-            }
-        ],
-        "count": 2.0,
-        "alen": 869,
-        "length": 869,
-        "eff_nseq": 0.8,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 1,
-            "Caulimoviridae": 1
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Badnavirus": 1
-        }
-    },
-    {
-        "cluster": "236",
-        "names": [
-            "capsid maturation protease",
-            "capsid maturation protease UL26"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227259.1",
-                "name": "capsid maturation protease",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230157.1",
-                "name": "capsid maturation protease UL26",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 603,
-        "length": 603,
-        "eff_nseq": 0.56,
-        "mean_entropy": 0.589,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "237",
-        "names": [
-            "ribonucleotide reductase subunit 2",
-            "UL40 ribonucleotide reductase subunit 2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227273.1",
-                "name": "ribonucleotide reductase subunit 2",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230171.1",
-                "name": "UL40 ribonucleotide reductase subunit 2",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 329,
-        "length": 329,
-        "eff_nseq": 0.56,
-        "mean_entropy": 0.594,
-        "total_entropy": 1.19,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "238",
-        "names": [
-            "nucleoprotein",
-            "sRNA nucleoprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227130.1",
-                "name": "sRNA nucleoprotein",
-                "organism": "Adana virus"
-            },
-            {
-                "accession": "YP_009480532.1",
-                "name": "nucleoprotein",
-                "organism": "Arrabida virus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 256,
-        "length": 256,
-        "eff_nseq": 0.53,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Phlebovirus": 2
-        },
-        "genera": {
-            "unclassified Phlebovirus": 1,
-            "Adana phlebovirus": 1
-        }
-    },
-    {
-        "cluster": "239",
-        "names": [
-            "tegument protein",
-            "tegument protein UL7"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227240.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230137.1",
-                "name": "tegument protein UL7",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 295,
-        "length": 295,
-        "eff_nseq": 0.52,
-        "mean_entropy": 0.593,
-        "total_entropy": 1.19,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "24",
-        "names": [
-            "hypothetical protein",
-            "C' protein",
-            "alpha 2 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176980.1",
-                "name": "C' protein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009177245.1",
-                "name": "alpha 2 protein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009182152.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
-            },
-            {
-                "accession": "YP_009182243.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186810.1",
-                "name": "egt",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229955.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229957.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 896,
-        "length": 343,
-        "eff_nseq": 2.46,
-        "mean_entropy": 0.589,
-        "total_entropy": 4.12,
-        "mean_positional_relative_entropy": 0.45,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Sunrhavirus": 1,
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 4,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Ephemerovirus": 1,
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1
-        }
-    },
-    {
-        "cluster": "240",
-        "names": [
-            "ME53",
-            "me-53"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182323.1",
-                "name": "ME53",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009230037.1",
-                "name": "me-53",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 332,
-        "length": 332,
-        "eff_nseq": 0.48,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "241",
-        "names": [
-            "endonuclease",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186783.1",
-                "name": "endonuclease",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230024.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 126,
-        "length": 126,
-        "eff_nseq": 0.6,
-        "mean_entropy": 0.588,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "242",
-        "names": [
-            "sod"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186793.1",
-                "name": "sod",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229947.1",
-                "name": "sod",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 2.0,
-        "alen": 170,
-        "length": 170,
-        "eff_nseq": 0.49,
-        "mean_entropy": 0.591,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "243",
-        "names": [
-            "envelope glycoprotein L",
-            "envelope glycoprotein UL1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227236.1",
-                "name": "envelope glycoprotein L",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230131.1",
-                "name": "envelope glycoprotein UL1",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 2.0,
-        "alen": 192,
-        "length": 192,
-        "eff_nseq": 0.53,
-        "mean_entropy": 0.592,
-        "total_entropy": 1.18,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "244",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009218534.1",
-                "name": "hypothetical protein",
-                "organism": "Parabacteroides phage YZ-2015a"
-            },
-            {
-                "accession": "YP_009218803.1",
-                "name": "hypothetical protein",
-                "organism": "Parabacteroides phage YZ-2015b"
-            }
-        ],
-        "count": 2.0,
-        "alen": 119,
-        "length": 119,
-        "eff_nseq": 0.5,
-        "mean_entropy": 0.587,
-        "total_entropy": 1.17,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Microviridae": 2
-        },
-        "genera": {
-            "unclassified Microviridae": 2
-        }
-    },
-    {
-        "cluster": "25",
-        "names": [
-            "P protein",
-            "hypothetical protein",
-            "ribonucleotide reductase 2a"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177223.1",
-                "name": "P protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009182237.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182314.1",
-                "name": "ribonucleotide reductase 2a",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186805.1",
-                "name": "ac111",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186811.1",
-                "name": "orf120",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009194638.1",
-                "name": "polyprotein ORF1a",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199240.1",
-                "name": "replicase polyprotein 1a",
-                "organism": "Swine enteric coronavirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 4253,
-        "length": 988,
-        "eff_nseq": 1.64,
-        "mean_entropy": 0.589,
-        "total_entropy": 4.12,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Betarhabdovirinae": 1,
-            "Baculoviridae": 4,
-            "Alphacoronavirus": 2
-        },
-        "genera": {
-            "Cytorhabdovirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2,
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1
-        }
-    },
-    {
-        "cluster": "26",
-        "names": [
-            "hypothetical protein",
-            "ribonucleotide reductase subunit 1",
-            "ribonucleotide reductase 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182217.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182313.1",
-                "name": "ribonucleotide reductase 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186822.1",
-                "name": "dna photolyase",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009227272.1",
-                "name": "ribonucleotide reductase subunit 1",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009229942.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230012.1",
-                "name": "rr1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230170.1",
-                "name": "ribonucleotide reductase subunit 1",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 7.0,
-        "alen": 1005,
-        "length": 797,
-        "eff_nseq": 1.97,
-        "mean_entropy": 0.589,
-        "total_entropy": 4.12,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 5,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 4,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "27",
-        "names": [
-            "hypothetical protein 4",
-            "beta protein",
-            "183 kDa replicase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177011.1",
-                "name": "hypothetical protein 4",
-                "organism": "Kumasi rhabdovirus"
-            },
-            {
-                "accession": "YP_009177213.1",
-                "name": "beta protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009182168.1",
-                "name": "183 kDa replicase",
-                "organism": "Tomato brown rugose fruit virus"
-            },
-            {
-                "accession": "YP_009182169.1",
-                "name": "126 kDa replicase",
-                "organism": "Tomato brown rugose fruit virus"
-            },
-            {
-                "accession": "YP_009220366.1",
-                "name": "putative replicase",
-                "organism": "Colombian potato soil-borne virus"
-            },
-            {
-                "accession": "YP_009220367.1",
-                "name": "polymerase",
-                "organism": "Colombian potato soil-borne virus"
-            },
-            {
-                "accession": "YP_009230003.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 1899,
-        "length": 1585,
-        "eff_nseq": 1.43,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alpharhabdovirinae": 2,
-            "Virgaviridae": 4,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "Ledantevirus": 1,
-            "Ephemerovirus": 1,
-            "Tobamovirus": 2,
-            "Pomovirus": 2,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "28",
-        "names": [
-            "capsid protein",
-            "hypothetical protein",
-            "matrix protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176975.1",
-                "name": "matrix protein",
-                "organism": "Datura yellow vein nucleorhabdovirus"
-            },
-            {
-                "accession": "YP_009182173.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 1"
-            },
-            {
-                "accession": "YP_009182175.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 2"
-            },
-            {
-                "accession": "YP_009182180.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 3"
-            },
-            {
-                "accession": "YP_009225664.1",
-                "name": "putative coat protein",
-                "organism": "Panax notoginseng virus A"
-            },
-            {
-                "accession": "YP_009229933.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229938.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 820,
-        "length": 579,
-        "eff_nseq": 2.64,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Rhabdoviridae": 1,
-            "Ghabrivirales": 4,
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Nucleorhabdovirus": 1,
-            "Totiviridae": 4,
-            "Betabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "29",
-        "names": [
-            "putative nucleoprotein",
-            "ORF3"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177220.1",
-                "name": "ORF3",
-                "organism": "Suffolk virus"
-            },
-            {
-                "accession": "YP_009177703.1",
-                "name": "putative nucleoprotein",
-                "organism": "Bole Tick Virus 3"
-            },
-            {
-                "accession": "YP_009177706.1",
-                "name": "putative nucleoprotein",
-                "organism": "Changping Tick Virus 2"
-            },
-            {
-                "accession": "YP_009177708.1",
-                "name": "putative nucleoprotein",
-                "organism": "Changping Tick Virus 3"
-            },
-            {
-                "accession": "YP_009177715.1",
-                "name": "putative nucleoprotein",
-                "organism": "Tacheng Tick Virus 4"
-            },
-            {
-                "accession": "YP_009177718.1",
-                "name": "putative nucleoprotein",
-                "organism": "Tacheng Tick Virus 5"
-            },
-            {
-                "accession": "YP_009177724.1",
-                "name": "putative nucleoprotein",
-                "organism": "Wuhan tick virus 2"
-            }
-        ],
-        "count": 7.0,
-        "alen": 565,
-        "length": 430,
-        "eff_nseq": 1.41,
-        "mean_entropy": 0.589,
-        "total_entropy": 4.12,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Mivirus": 3,
-            "unclassified ssRNA viruses": 3,
-            "Rhabdoviridae": 1
-        },
-        "genera": {
-            "Suffolk mivirus": 1,
-            "unclassified ssRNA negative-strand viruses": 3,
-            "Argas mivirus": 1,
-            "Bole mivirus": 1,
-            "unclassified Rhabdoviridae": 1
-        }
-    },
-    {
-        "cluster": "3",
-        "names": [
-            "replicase polyprotein",
-            "replicase",
-            "polyprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177225.1",
-                "name": "4 protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009182274.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182337.1",
-                "name": "84 kDa protein",
-                "organism": "Penicillium janczewskii chrysovirus 1"
-            },
-            {
-                "accession": "YP_009186834.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Actinidia virus X"
-            },
-            {
-                "accession": "YP_009204561.1",
-                "name": "replicase",
-                "organism": "Asian prunus virus 2"
-            },
-            {
-                "accession": "YP_009215374.1",
-                "name": "replicase",
-                "organism": "Asian prunus virus 3"
-            },
-            {
-                "accession": "YP_009222597.1",
-                "name": "polyprotein",
-                "organism": "Nectarine marafivirus M"
-            },
-            {
-                "accession": "YP_009224928.1",
-                "name": "replicase polyprotein",
-                "organism": "Elderberry carlavirus A"
-            },
-            {
-                "accession": "YP_009224934.1",
-                "name": "replicase polyprotein",
-                "organism": "Elderberry carlavirus B"
-            },
-            {
-                "accession": "YP_009224940.1",
-                "name": "replicase polyprotein",
-                "organism": "Elderberry carlavirus C"
-            },
-            {
-                "accession": "YP_009224946.1",
-                "name": "replicase polyprotein",
-                "organism": "Elderberry carlavirus D"
-            },
-            {
-                "accession": "YP_009224952.1",
-                "name": "replicase polyprotein",
-                "organism": "Elderberry carlavirus E"
-            },
-            {
-                "accession": "YP_009229912.1",
-                "name": "polyprotein",
-                "organism": "Currant virus A"
-            }
-        ],
-        "count": 13.0,
-        "alen": 3017,
-        "length": 1718,
-        "eff_nseq": 2.47,
-        "mean_entropy": 0.59,
-        "total_entropy": 7.67,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Betarhabdovirinae": 1,
-            "Baculoviridae": 1,
-            "Chrysoviridae": 1,
-            "Alphaflexiviridae": 1,
-            "Foveavirus": 1,
-            "Quinvirinae": 4,
-            "Carlavirus": 2,
-            "Tymoviridae": 1,
-            "Trivirinae": 1
-        },
-        "genera": {
-            "Cytorhabdovirus": 1,
-            "Betabaculovirus": 1,
-            "Betachrysovirus": 1,
-            "Potexvirus": 1,
-            "unclassified Foveavirus": 1,
-            "Foveavirus": 1,
-            "Carlavirus": 3,
-            "unclassified Carlavirus": 2,
-            "Marafivirus": 1,
-            "Capillovirus": 1
-        }
-    },
-    {
-        "cluster": "30",
-        "names": [
-            "nucleoprotein",
-            "N",
-            "nucleocapsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176966.1",
-                "name": "N",
-                "organism": "Inhangapi virus"
-            },
-            {
-                "accession": "YP_009176978.1",
-                "name": "nucleoprotein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009177008.1",
-                "name": "N",
-                "organism": "Kumasi rhabdovirus"
-            },
-            {
-                "accession": "YP_009177193.1",
-                "name": "nucleoprotein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177205.1",
-                "name": "nucleoprotein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177239.1",
-                "name": "nucleocapsid protein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009177647.1",
-                "name": "nucleocapsid protein",
-                "organism": "Cocal virus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 445,
-        "length": 425,
-        "eff_nseq": 1.06,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.54,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Sunrhavirus": 1,
-            "Alpharhabdovirinae": 5
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Ephemerovirus": 3,
-            "Ledantevirus": 1,
-            "Vesiculovirus": 1
-        }
-    },
-    {
-        "cluster": "31",
-        "names": [
-            "helicase",
-            "hypothetical protein",
-            "DNA-helicase-2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182280.1",
-                "name": "DNA-helicase-2",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186770.1",
-                "name": "helicase",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009220373.1",
-                "name": "triple gene block protein 3",
-                "organism": "Colombian potato soil-borne virus"
-            },
-            {
-                "accession": "YP_009220473.1",
-                "name": "3B",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009229991.1",
-                "name": "helicase",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230169.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230173.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 7.0,
-        "alen": 1304,
-        "length": 718,
-        "eff_nseq": 1.79,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3,
-            "Hepatovirus": 1,
-            "Virgaviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "unclassified Hepatovirus": 1,
-            "Pomovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "32",
-        "names": [
-            "small envelope protein",
-            "envelope protein",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009194641.1",
-                "name": "envelope protein",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199245.1",
-                "name": "envelope protein",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199611.1",
-                "name": "small envelope protein",
-                "organism": "BtMr-AlphaCoV/SAX2011"
-            },
-            {
-                "accession": "YP_009199792.1",
-                "name": "small envelope protein",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009200737.1",
-                "name": "small envelope protein",
-                "organism": "BtRf-AlphaCoV/YN2012"
-            },
-            {
-                "accession": "YP_009201732.1",
-                "name": "small envelope protein",
-                "organism": "BtNv-AlphaCoV/SC2013"
-            },
-            {
-                "accession": "YP_009230193.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 7.0,
-        "alen": 682,
-        "length": 171,
-        "eff_nseq": 1.32,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alphacoronavirus": 2,
-            "Rhinacovirus": 1,
-            "Decacovirus": 1,
-            "Nyctacovirus": 1,
-            "Myotacovirus": 1,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1,
-            "unclassified Rhinacovirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
-            "Myotis ricketti alphacoronavirus Sax-2011": 1,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "33",
-        "names": [
-            "G protein",
-            "immediate early protein 1",
-            "ie-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177229.1",
-                "name": "G protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009182204.1",
-                "name": "immediate early protein 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186714.1",
-                "name": "ie-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009220471.1",
-                "name": "2B",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009229925.1",
-                "name": "ep23",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229943.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009480343.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 716,
-        "length": 458,
-        "eff_nseq": 2.94,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Betarhabdovirinae": 1,
-            "Baculoviridae": 4,
-            "Spinareovirinae": 1,
-            "Hepatovirus": 1
-        },
-        "genera": {
-            "Cytorhabdovirus": 1,
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1,
-            "unclassified Hepatovirus": 1
-        }
-    },
-    {
-        "cluster": "34",
-        "names": [
-            "polyhedron envelope protein 2",
-            "p10",
-            "calyx/pep"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009059067.1",
-                "name": "hypothetical protein",
-                "organism": "Cimodo virus"
-            },
-            {
-                "accession": "YP_009182215.1",
-                "name": "polyhedron envelope protein 2",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186700.1",
-                "name": "p10",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186795.1",
-                "name": "calyx/pep",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186815.1",
-                "name": "orf124",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009222004.1",
-                "name": "ORF5a protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009229937.1",
-                "name": "pep-2",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 591,
-        "length": 185,
-        "eff_nseq": 2.67,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.43,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 5,
-            "Kaftartevirus": 1,
-            "Reoviridae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 3,
-            "Thetaarterivirus kafuba": 1,
-            "unclassified Reoviridae": 1
-        }
-    },
-    {
-        "cluster": "35",
-        "names": [
-            "bro-2",
-            "bro-3",
-            "bro-4"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186738.1",
-                "name": "bro-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186742.1",
-                "name": "bro-3",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186821.1",
-                "name": "bro-4",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229976.1",
-                "name": "bro-A",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009229985.1",
-                "name": "P12",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230004.1",
-                "name": "bro-B",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230035.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 7.0,
-        "alen": 503,
-        "length": 263,
-        "eff_nseq": 3.11,
-        "mean_entropy": 0.59,
-        "total_entropy": 4.13,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 7
-        },
-        "genera": {
-            "Alphabaculovirus": 3,
-            "Betabaculovirus": 4
-        }
-    },
-    {
-        "cluster": "36",
-        "names": [
-            "NS3-like protein",
-            "orf34"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179379.1",
-                "name": "NS3-like protein",
-                "organism": "Wuhan aphid virus 2"
-            },
-            {
-                "accession": "YP_009179389.1",
-                "name": "NS3-like protein",
-                "organism": "Wuhan aphid virus 1"
-            },
-            {
-                "accession": "YP_009179400.1",
-                "name": "NS3-like protein",
-                "organism": "Wuhan cricket virus"
-            },
-            {
-                "accession": "YP_009179402.1",
-                "name": "NS3-like protein",
-                "organism": "Shuangao insect virus 7"
-            },
-            {
-                "accession": "YP_009179404.1",
-                "name": "NS3-like protein",
-                "organism": "Wuhan flea virus"
-            },
-            {
-                "accession": "YP_009186725.1",
-                "name": "orf34",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 831,
-        "length": 809,
-        "eff_nseq": 1.09,
-        "mean_entropy": 0.591,
-        "total_entropy": 3.55,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "unclassified ssRNA viruses": 5,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "unclassified ssRNA positive-strand viruses": 5,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "37",
-        "names": [
-            "NS5-like protein",
-            "N protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179378.1",
-                "name": "NS5-like protein",
-                "organism": "Wuhan aphid virus 2"
-            },
-            {
-                "accession": "YP_009179388.1",
-                "name": "NS5-like protein",
-                "organism": "Wuhan aphid virus 1"
-            },
-            {
-                "accession": "YP_009179401.1",
-                "name": "NS5-like protein",
-                "organism": "Shuangao insect virus 7"
-            },
-            {
-                "accession": "YP_009179403.1",
-                "name": "NS5-like protein",
-                "organism": "Wuhan flea virus"
-            },
-            {
-                "accession": "YP_009179405.1",
-                "name": "NS5-like protein",
-                "organism": "Wuhan cricket virus"
-            },
-            {
-                "accession": "YP_009222006.1",
-                "name": "N protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 951,
-        "length": 904,
-        "eff_nseq": 0.85,
-        "mean_entropy": 0.592,
-        "total_entropy": 3.55,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "unclassified ssRNA viruses": 5,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "unclassified ssRNA positive-strand viruses": 5,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "38",
-        "names": [
-            "polyprotein",
-            "6K1 protein",
-            "CI"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175089.1",
-                "name": "polyprotein",
-                "organism": "Rice necrosis mosaic virus"
-            },
-            {
-                "accession": "YP_009221986.1",
-                "name": "6K1 protein",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009221987.1",
-                "name": "CI",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009221990.1",
-                "name": "NIa-Pro",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009221991.1",
-                "name": "NIb",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009221992.1",
-                "name": "CP",
-                "organism": "Jasmine virus T"
-            }
-        ],
-        "count": 6.0,
-        "alen": 2296,
-        "length": 691,
-        "eff_nseq": 2.28,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Potyviridae": 6
-        },
-        "genera": {
-            "Bymovirus": 1,
-            "Potyvirus": 5
-        }
-    },
-    {
-        "cluster": "39",
-        "names": [
-            "spike glycoprotein",
-            "spike protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009194639.1",
-                "name": "spike protein",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199242.1",
-                "name": "spike protein",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199609.1",
-                "name": "spike glycoprotein",
-                "organism": "BtMr-AlphaCoV/SAX2011"
-            },
-            {
-                "accession": "YP_009199790.1",
-                "name": "spike glycoprotein",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009200735.1",
-                "name": "spike glycoprotein",
-                "organism": "BtRf-AlphaCoV/YN2012"
-            },
-            {
-                "accession": "YP_009201730.1",
-                "name": "spike glycoprotein",
-                "organism": "BtNv-AlphaCoV/SC2013"
-            }
-        ],
-        "count": 6.0,
-        "alen": 1474,
-        "length": 1362,
-        "eff_nseq": 0.85,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alphacoronavirus": 2,
-            "Rhinacovirus": 1,
-            "Decacovirus": 1,
-            "Nyctacovirus": 1,
-            "Myotacovirus": 1
-        },
-        "genera": {
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1,
-            "unclassified Rhinacovirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
-            "Myotis ricketti alphacoronavirus Sax-2011": 1
-        }
-    },
-    {
-        "cluster": "4",
-        "names": [
-            "polyprotein",
-            "6 protein",
-            "3D"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175074.1",
-                "name": "polyprotein",
-                "organism": "Bean rugose mosaic virus"
-            },
-            {
-                "accession": "YP_009177204.1",
-                "name": "polyprotein",
-                "organism": "Posavirus 3"
-            },
-            {
-                "accession": "YP_009177227.1",
-                "name": "6 protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009214667.1",
-                "name": "polyprotein",
-                "organism": "Gallivirus Pf-CHK1/GV"
-            },
-            {
-                "accession": "YP_009215118.1",
-                "name": "polyprotein",
-                "organism": "Avisivirus Pf-CHK1/AsV"
-            },
-            {
-                "accession": "YP_009220374.1",
-                "name": "polyprotein",
-                "organism": "Currant latent virus"
-            },
-            {
-                "accession": "YP_009220464.1",
-                "name": "3D",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009220465.1",
-                "name": "2C",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009220468.1",
-                "name": "VP2",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009220469.1",
-                "name": "3C",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009221981.1",
-                "name": "nonstructural polyprotein",
-                "organism": "Goose dicistrovirus"
-            },
-            {
-                "accession": "YP_009227212.1",
-                "name": "predicted replication-associated polyprotein",
-                "organism": "Delisea pulchra RNA virus"
-            }
-        ],
-        "count": 12.0,
-        "alen": 3374,
-        "length": 1926,
-        "eff_nseq": 5.74,
-        "mean_entropy": 0.59,
-        "total_entropy": 7.08,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Comovirinae": 1,
-            "unclassified Picornavirales": 1,
-            "Betarhabdovirinae": 1,
-            "Hepatovirus": 4,
-            "Avisivirus": 1,
-            "Gallivirus": 1,
-            "Secoviridae": 1,
-            "Dicistroviridae": 1,
-            "Picornavirales": 1
-        },
-        "genera": {
-            "Comovirus": 1,
-            "Posavirus": 1,
-            "Cytorhabdovirus": 1,
-            "unclassified Hepatovirus": 4,
-            "unclassified Avisivirus": 1,
-            "unclassified Gallivirus": 1,
-            "Cheravirus": 1,
-            "unclassified Dicistroviridae": 1,
-            "unclassified Picornavirales": 1
-        }
-    },
-    {
-        "cluster": "40",
-        "names": [
-            "iap-3",
-            "inhibitor of apoptosis 3",
-            "inhibitor of apoptosis 5"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182263.1",
-                "name": "inhibitor of apoptosis 3",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182301.1",
-                "name": "inhibitor of apoptosis 5",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186727.1",
-                "name": "iap-3",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186750.1",
-                "name": "iap-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186787.1",
-                "name": "iap-3",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230020.1",
-                "name": "iap-5",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 378,
-        "length": 252,
-        "eff_nseq": 1.19,
-        "mean_entropy": 0.589,
-        "total_entropy": 3.53,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.06,
-        "families": {
-            "Baculoviridae": 6
-        },
-        "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "41",
-        "names": [
-            "fusion protein",
-            "alpha1 protein",
-            "dUTPase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177210.1",
-                "name": "alpha1 protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177602.1",
-                "name": "fusion protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009179210.1",
-                "name": "fusion protein",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009182277.1",
-                "name": "dUTPase",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186686.1",
-                "name": "agnoprotein",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009480336.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 1470,
-        "length": 733,
-        "eff_nseq": 1.75,
-        "mean_entropy": 0.589,
-        "total_entropy": 3.53,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Orthoparamyxovirinae": 1,
-            "Respirovirus": 1,
-            "Baculoviridae": 1,
-            "Polyomaviridae": 1,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Morbillivirus": 1,
-            "Caprine respirovirus 3": 1,
-            "Betabaculovirus": 1,
-            "Betapolyomavirus": 1,
-            "Fijivirus": 1
-        }
-    },
-    {
-        "cluster": "42",
-        "names": [
-            "nucleic acid binding protein",
-            "orf126"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186817.1",
-                "name": "orf126",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009224933.1",
-                "name": "nucleic acid binding protein",
-                "organism": "Elderberry carlavirus A"
-            },
-            {
-                "accession": "YP_009224939.1",
-                "name": "nucleic acid binding protein",
-                "organism": "Elderberry carlavirus B"
-            },
-            {
-                "accession": "YP_009224945.1",
-                "name": "nucleic acid binding protein",
-                "organism": "Elderberry carlavirus C"
-            },
-            {
-                "accession": "YP_009224951.1",
-                "name": "nucleic acid binding protein",
-                "organism": "Elderberry carlavirus D"
-            },
-            {
-                "accession": "YP_009224957.1",
-                "name": "nucleic acid binding protein",
-                "organism": "Elderberry carlavirus E"
-            }
-        ],
-        "count": 6.0,
-        "alen": 256,
-        "length": 129,
-        "eff_nseq": 1.38,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 1,
-            "Quinvirinae": 3,
-            "Carlavirus": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Carlavirus": 3,
-            "unclassified Carlavirus": 2
-        }
-    },
-    {
-        "cluster": "43",
-        "names": [
-            "capsid protein",
-            "hoar",
-            "structural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182187.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 5"
-            },
-            {
-                "accession": "YP_009182189.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 6"
-            },
-            {
-                "accession": "YP_009182194.1",
-                "name": "capsid protein",
-                "organism": "Red clover powdery mildew-associated totivirus 7"
-            },
-            {
-                "accession": "YP_009186695.1",
-                "name": "hoar",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009222002.1",
-                "name": "GP4 protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009480346.1",
-                "name": "structural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 1241,
-        "length": 821,
-        "eff_nseq": 2.21,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Ghabrivirales": 3,
-            "Baculoviridae": 1,
-            "Spinareovirinae": 1,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Totiviridae": 3,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "44",
-        "names": [
-            "NS1",
-            "nonstructural protein",
-            "nonstructural protein 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175068.1",
-                "name": "nonstructural protein",
-                "organism": "Ungulate tetraparvovirus 1"
-            },
-            {
-                "accession": "YP_009186840.1",
-                "name": "NS1",
-                "organism": "Rat bufavirus SY-2015"
-            },
-            {
-                "accession": "YP_009215301.1",
-                "name": "nonstructural protein 1",
-                "organism": "Lagomorph bocaparvovirus 1"
-            },
-            {
-                "accession": "YP_009227290.1",
-                "name": "NS2",
-                "organism": "Rat bocavirus"
-            },
-            {
-                "accession": "YP_009227291.1",
-                "name": "NS1",
-                "organism": "Rat bocavirus"
-            },
-            {
-                "accession": "YP_009229908.1",
-                "name": "NS1 protein",
-                "organism": "Bat bocavirus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 869,
-        "length": 752,
-        "eff_nseq": 1.25,
-        "mean_entropy": 0.591,
-        "total_entropy": 3.55,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Parvovirinae": 3,
-            "Bocaparvovirus": 3
-        },
-        "genera": {
-            "Tetraparvovirus": 1,
-            "Protoparvovirus": 1,
-            "Bocaparvovirus": 1,
-            "Rodent bocaparvovirus 1": 2,
-            "unclassified Bocaparvovirus": 1
-        }
-    },
-    {
-        "cluster": "45",
-        "names": [
-            "beta protein",
-            "alpha2 protein",
-            "9 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177200.1",
-                "name": "beta protein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177211.1",
-                "name": "alpha2 protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177230.1",
-                "name": "9 protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009209481.1",
-                "name": "ORF1",
-                "organism": "Thelephora terrestris virus 1"
-            },
-            {
-                "accession": "YP_009227123.1",
-                "name": "putative coat protein",
-                "organism": "Rosellinia necatrix megabirnavirus 2-W8"
-            },
-            {
-                "accession": "YP_009227289.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            }
-        ],
-        "count": 6.0,
-        "alen": 1845,
-        "length": 459,
-        "eff_nseq": 2.39,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.41,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alpharhabdovirinae": 2,
-            "Betarhabdovirinae": 1,
-            "Ghabrivirales": 1,
-            "Alphaherpesvirinae": 1,
-            "Megabirnavirus": 1
-        },
-        "genera": {
-            "Ephemerovirus": 2,
-            "Cytorhabdovirus": 1,
-            "Totiviridae": 1,
-            "Simplexvirus": 1,
-            "unclassified Megabirnavirus": 1
-        }
-    },
-    {
-        "cluster": "46",
-        "names": [
-            "AC4 protein",
-            "AC4",
-            "C4 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175079.1",
-                "name": "AC4 protein",
-                "organism": "Melochia mosaic virus"
-            },
-            {
-                "accession": "YP_009175086.1",
-                "name": "AC4 protein",
-                "organism": "Melochia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009216264.1",
-                "name": "C4 protein",
-                "organism": "Okra leaf curl Oman virus"
-            },
-            {
-                "accession": "YP_009216587.1",
-                "name": "AC4",
-                "organism": "Pepper yellow leaf curl Thailand virus"
-            },
-            {
-                "accession": "YP_009226418.1",
-                "name": "ac4 protein",
-                "organism": "Pavonia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009226628.1",
-                "name": "C4",
-                "organism": "Turnip leaf roll virus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 99,
-        "length": 85,
-        "eff_nseq": 1.4,
-        "mean_entropy": 0.669,
-        "total_entropy": 4.01,
-        "mean_positional_relative_entropy": 0.63,
-        "kullback_leibler_divergence": 0.06,
-        "families": {
-            "Geminiviridae": 6
-        },
-        "genera": {
-            "Begomovirus": 5,
-            "Turncurtovirus": 1
-        }
-    },
-    {
-        "cluster": "47",
-        "names": [
-            "hypothetical protein ORF3",
-            "ORF4",
-            "non-structural protein 3b"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009194640.1",
-                "name": "ORF4",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199244.1",
-                "name": "non-structural protein 3b",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199610.1",
-                "name": "hypothetical protein ORF3",
-                "organism": "BtMr-AlphaCoV/SAX2011"
-            },
-            {
-                "accession": "YP_009199791.1",
-                "name": "hypothetical protein ORF3",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009200736.1",
-                "name": "hypothetical protein ORF3",
-                "organism": "BtRf-AlphaCoV/YN2012"
-            },
-            {
-                "accession": "YP_009201731.1",
-                "name": "hypothetical protein ORF3",
-                "organism": "BtNv-AlphaCoV/SC2013"
-            }
-        ],
-        "count": 6.0,
-        "alen": 249,
-        "length": 229,
-        "eff_nseq": 0.91,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Alphacoronavirus": 2,
-            "Rhinacovirus": 1,
-            "Decacovirus": 1,
-            "Nyctacovirus": 1,
-            "Myotacovirus": 1
-        },
-        "genera": {
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1,
-            "unclassified Rhinacovirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
-            "Myotis ricketti alphacoronavirus Sax-2011": 1
-        }
-    },
-    {
-        "cluster": "48",
-        "names": [
-            "membrane glycoprotein",
-            "membrane protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009194642.1",
-                "name": "membrane protein",
-                "organism": "Camel alphacoronavirus"
-            },
-            {
-                "accession": "YP_009199246.1",
-                "name": "membrane protein",
-                "organism": "Swine enteric coronavirus"
-            },
-            {
-                "accession": "YP_009199612.1",
-                "name": "membrane glycoprotein",
-                "organism": "BtMr-AlphaCoV/SAX2011"
-            },
-            {
-                "accession": "YP_009199793.1",
-                "name": "membrane glycoprotein",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009200738.1",
-                "name": "membrane glycoprotein",
-                "organism": "BtRf-AlphaCoV/YN2012"
-            },
-            {
-                "accession": "YP_009201733.1",
-                "name": "membrane glycoprotein",
-                "organism": "BtNv-AlphaCoV/SC2013"
-            }
-        ],
-        "count": 6.0,
-        "alen": 263,
-        "length": 228,
-        "eff_nseq": 0.52,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Alphacoronavirus": 2,
-            "Rhinacovirus": 1,
-            "Decacovirus": 1,
-            "Nyctacovirus": 1,
-            "Myotacovirus": 1
-        },
-        "genera": {
-            "Duvinacovirus": 1,
-            "Tegacovirus": 1,
-            "unclassified Rhinacovirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Nyctalus velutinus alphacoronavirus SC-2013": 1,
-            "Myotis ricketti alphacoronavirus Sax-2011": 1
-        }
-    },
-    {
-        "cluster": "49",
-        "names": [
-            "hypothetical protein",
-            "orf25",
-            "triple gene block protein 1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182269.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182310.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186716.1",
-                "name": "orf25",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009220371.1",
-                "name": "triple gene block protein 1",
-                "organism": "Colombian potato soil-borne virus"
-            },
-            {
-                "accession": "YP_009229916.1",
-                "name": "structural protein",
-                "organism": "Piscine myocarditis-like virus"
-            },
-            {
-                "accession": "YP_009229983.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 6.0,
-        "alen": 511,
-        "length": 240,
-        "eff_nseq": 2.71,
-        "mean_entropy": 0.59,
-        "total_entropy": 3.54,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 4,
-            "Virgaviridae": 1,
-            "Ghabrivirales": 1
-        },
-        "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1,
-            "Pomovirus": 1,
-            "Totiviridae": 1
-        }
-    },
-    {
-        "cluster": "5",
-        "names": [
-            "transactivator protein",
-            "transcriptional activator protein",
-            "transactivation protein"
-        ],
-        "entries": [
-            {
-                "accession": "NP_835274.1",
-                "name": "transactivation protein",
-                "organism": "Melon chlorotic leaf curl virus-"
-            },
-            {
-                "accession": "YP_009175077.1",
-                "name": "transactivator protein",
-                "organism": "Melochia mosaic virus"
-            },
-            {
-                "accession": "YP_009175084.1",
-                "name": "transactivator protein",
-                "organism": "Melochia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009177712.1",
-                "name": "transcriptional activator protein",
-                "organism": "Andrographis yellow vein leaf curl virus"
-            },
-            {
-                "accession": "YP_009186701.1",
-                "name": "p26-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186747.1",
-                "name": "p26-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009216262.1",
-                "name": "transcriptional activator protein",
-                "organism": "Okra leaf curl Oman virus"
-            },
-            {
-                "accession": "YP_009216585.1",
-                "name": "AC2",
-                "organism": "Pepper yellow leaf curl Thailand virus"
-            },
-            {
-                "accession": "YP_009226416.1",
-                "name": "transactivating protein",
-                "organism": "Pavonia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009226626.1",
-                "name": "C2",
-                "organism": "Turnip leaf roll virus"
-            },
-            {
-                "accession": "YP_009229913.1",
-                "name": "movement protein",
-                "organism": "Currant virus A"
-            }
-        ],
-        "count": 11.0,
-        "alen": 584,
-        "length": 154,
-        "eff_nseq": 2.26,
-        "mean_entropy": 0.59,
-        "total_entropy": 6.49,
-        "mean_positional_relative_entropy": 0.44,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Geminiviridae": 8,
-            "Baculoviridae": 2,
-            "Trivirinae": 1
-        },
-        "genera": {
-            "Begomovirus": 7,
-            "Alphabaculovirus": 2,
-            "Turncurtovirus": 1,
-            "Capillovirus": 1
-        }
-    },
-    {
-        "cluster": "50",
-        "names": [
-            "vlf-1",
-            "very late factor 1",
-            "ac55"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182291.1",
-                "name": "very late factor 1",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186733.1",
-                "name": "ac55",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186757.1",
-                "name": "vlf-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009226564.1",
-                "name": "hypothetical protein",
-                "organism": "Ctenophore-associated circular virus 2"
-            },
-            {
-                "accession": "YP_009230009.1",
-                "name": "vlf-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 400,
-        "length": 360,
-        "eff_nseq": 1.2,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4,
-            "unclassified DNA viruses": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2,
-            "unclassified ssDNA viruses": 1
-        }
-    },
-    {
-        "cluster": "51",
-        "names": [
-            "putative glycoprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179381.1",
-                "name": "putative glycoprotein",
-                "organism": "Wuhan aphid virus 1"
-            },
-            {
-                "accession": "YP_009179385.1",
-                "name": "putative glycoprotein",
-                "organism": "Wuhan aphid virus 2"
-            },
-            {
-                "accession": "YP_009179393.1",
-                "name": "putative glycoprotein",
-                "organism": "Shuangao insect virus 7"
-            },
-            {
-                "accession": "YP_009179397.1",
-                "name": "putative glycoprotein",
-                "organism": "Wuhan flea virus"
-            },
-            {
-                "accession": "YP_009179407.1",
-                "name": "putative glycoprotein",
-                "organism": "Wuhan cricket virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 468,
-        "length": 374,
-        "eff_nseq": 1.39,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified ssRNA viruses": 5
-        },
-        "genera": {
-            "unclassified ssRNA positive-strand viruses": 5
-        }
-    },
-    {
-        "cluster": "52",
-        "names": [
-            "RNA-dependent RNA polymerase",
-            "orf53",
-            "RNA dependent RNA polymerase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182167.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Ustilaginoidea virens RNA virus 5"
-            },
-            {
-                "accession": "YP_009186744.1",
-                "name": "orf53",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009212848.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Penicillium aurantiogriseum totivirus 1"
-            },
-            {
-                "accession": "YP_009229915.1",
-                "name": "nonstructural protein",
-                "organism": "Piscine myocarditis-like virus"
-            },
-            {
-                "accession": "YP_009230208.1",
-                "name": "RdRp",
-                "organism": "Camponotus nipponicus virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 986,
-        "length": 850,
-        "eff_nseq": 1.78,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Victorivirus": 1,
-            "Baculoviridae": 1,
-            "Ghabrivirales": 3
-        },
-        "genera": {
-            "unclassified Victorivirus": 1,
-            "Alphabaculovirus": 1,
-            "Totiviridae": 3
-        }
-    },
-    {
-        "cluster": "53",
-        "names": [
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179383.1",
-                "name": "hypothetical protein",
-                "organism": "Wuhan aphid virus 1"
-            },
-            {
-                "accession": "YP_009179387.1",
-                "name": "hypothetical protein",
-                "organism": "Wuhan aphid virus 2"
-            },
-            {
-                "accession": "YP_009179395.1",
-                "name": "hypothetical protein",
-                "organism": "Shuangao insect virus 7"
-            },
-            {
-                "accession": "YP_009179399.1",
-                "name": "hypothetical protein",
-                "organism": "Wuhan flea virus"
-            },
-            {
-                "accession": "YP_009179409.1",
-                "name": "hypothetical protein",
-                "organism": "Wuhan cricket virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 608,
-        "length": 530,
-        "eff_nseq": 1.23,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified ssRNA viruses": 5
-        },
-        "genera": {
-            "unclassified ssRNA positive-strand viruses": 5
-        }
-    },
-    {
-        "cluster": "54",
-        "names": [
-            "E2",
-            "hypothetical protein",
-            "capsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177605.1",
-                "name": "capsid protein",
-                "organism": "Rosellinia necatrix partitivirus 6"
-            },
-            {
-                "accession": "YP_009177728.1",
-                "name": "E2",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182265.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182327.1",
-                "name": "E2",
-                "organism": "Rattus norvegicus papillomavirus 3"
-            },
-            {
-                "accession": "YP_009229978.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 747,
-        "length": 511,
-        "eff_nseq": 1.67,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Betapartitivirus": 1,
-            "Firstpapillomavirinae": 2,
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "unclassified Betapartitivirus": 1,
-            "Rhopapillomavirus": 1,
-            "Betabaculovirus": 2,
-            "Iotapapillomavirus": 1
-        }
-    },
-    {
-        "cluster": "55",
-        "names": [
-            "59 kDa protein",
-            "coat protein",
-            "A-protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_008999613.1",
-                "name": "coat protein",
-                "organism": "Eggplant mottled crinkle virus"
-            },
-            {
-                "accession": "YP_009182159.1",
-                "name": "59 kDa protein",
-                "organism": "Pleospora typhicola fusarivirus 1"
-            },
-            {
-                "accession": "YP_009208145.1",
-                "name": "A-protein",
-                "organism": "Escherichia virus FI"
-            },
-            {
-                "accession": "YP_009227281.1",
-                "name": "tegument protein VP22",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230183.1",
-                "name": "viral protein 22",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 5.0,
-        "alen": 569,
-        "length": 396,
-        "eff_nseq": 2.05,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified ssRNA viruses": 1,
-            "Procedovirinae": 1,
-            "Leviviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Fusariviridae": 1,
-            "Tombusvirus": 1,
-            "Allolevivirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "56",
-        "names": [
-            "putative capsid protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009179382.1",
-                "name": "putative capsid protein",
-                "organism": "Wuhan aphid virus 1"
-            },
-            {
-                "accession": "YP_009179386.1",
-                "name": "putative capsid protein",
-                "organism": "Wuhan aphid virus 2"
-            },
-            {
-                "accession": "YP_009179394.1",
-                "name": "putative capsid protein",
-                "organism": "Shuangao insect virus 7"
-            },
-            {
-                "accession": "YP_009179398.1",
-                "name": "putative capsid protein",
-                "organism": "Wuhan flea virus"
-            },
-            {
-                "accession": "YP_009179408.1",
-                "name": "putative capsid protein",
-                "organism": "Wuhan cricket virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 277,
-        "length": 260,
-        "eff_nseq": 1.2,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "unclassified ssRNA viruses": 5
-        },
-        "genera": {
-            "unclassified ssRNA positive-strand viruses": 5
-        }
-    },
-    {
-        "cluster": "57",
-        "names": [
-            "polyprotein",
-            "beta protein",
-            "30 kDa movement protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_008999614.1",
-                "name": "movement protein",
-                "organism": "Eggplant mottled crinkle virus"
-            },
-            {
-                "accession": "YP_009177246.1",
-                "name": "beta protein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009182100.1",
-                "name": "polyprotein",
-                "organism": "Blueberry fruit drop associated virus"
-            },
-            {
-                "accession": "YP_009182170.1",
-                "name": "30 kDa movement protein",
-                "organism": "Tomato brown rugose fruit virus"
-            },
-            {
-                "accession": "YP_009229919.1",
-                "name": "polyprotein",
-                "organism": "Blackberry virus F"
-            }
-        ],
-        "count": 5.0,
-        "alen": 2647,
-        "length": 915,
-        "eff_nseq": 1.48,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.45,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Virgaviridae": 1,
-            "Caulimoviridae": 2,
-            "Procedovirinae": 1
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Tobamovirus": 1,
-            "Vaccinivirus": 1,
-            "Tombusvirus": 1,
-            "Badnavirus": 1
-        }
-    },
-    {
-        "cluster": "58",
-        "names": [
-            "cg30-2",
-            "ac29",
-            "cg30-1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186699.1",
-                "name": "cg30-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186702.1",
-                "name": "ac29",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186763.1",
-                "name": "cg30-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009222005.1",
-                "name": "M protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009227216.1",
-                "name": "thymidylate synthase",
-                "organism": "Macropodid alphaherpesvirus 1"
-            }
-        ],
-        "count": 5.0,
-        "alen": 332,
-        "length": 286,
-        "eff_nseq": 2.33,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 3,
-            "Alphaherpesvirinae": 1,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Alphabaculovirus": 3,
-            "Simplexvirus": 1,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "59",
+        "cluster": "60",
         "names": [
             "hypothetical protein"
         ],
@@ -9219,524 +6247,277 @@
         }
     },
     {
-        "cluster": "6",
+        "cluster": "61",
         "names": [
-            "polymerase",
-            "L",
-            "RNA-dependent RNA polymerase"
+            "nuclear shuttle protein"
         ],
         "entries": [
             {
-                "accession": "YP_009176971.1",
-                "name": "L",
-                "organism": "Inhangapi virus"
+                "accession": "YP_009175072.1",
+                "name": "nuclear shuttle protein",
+                "organism": "Melon chlorotic leaf curl virus-"
             },
             {
-                "accession": "YP_009176977.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Datura yellow vein nucleorhabdovirus"
+                "accession": "YP_009175080.1",
+                "name": "nuclear shuttle protein",
+                "organism": "Melochia mosaic virus"
             },
             {
-                "accession": "YP_009176985.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Walkabout Creek virus"
+                "accession": "YP_009175087.1",
+                "name": "nuclear shuttle protein",
+                "organism": "Melochia yellow mosaic virus"
             },
             {
-                "accession": "YP_009177014.1",
-                "name": "L",
-                "organism": "Kumasi rhabdovirus"
-            },
-            {
-                "accession": "YP_009177203.1",
-                "name": "polymerase",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177215.1",
-                "name": "polymerase",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177231.1",
-                "name": "L protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009177247.1",
-                "name": "polymerase",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009177651.1",
-                "name": "L polymerase protein",
-                "organism": "Cocal virus"
-            },
-            {
-                "accession": "YP_009182315.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009204560.1",
-                "name": "L protein",
-                "organism": "Fox fecal rhabdovirus"
+                "accession": "YP_009480522.1",
+                "name": "nuclear shuttle protein",
+                "organism": "Pavonia yellow mosaic virus"
             }
         ],
-        "count": 11.0,
-        "alen": 2408,
-        "length": 2114,
-        "eff_nseq": 2.07,
-        "mean_entropy": 0.59,
-        "total_entropy": 6.49,
+        "count": 4.0,
+        "alen": 257,
+        "length": 256,
+        "eff_nseq": 0.46,
+        "mean_entropy": 0.588,
+        "total_entropy": 2.35,
         "mean_positional_relative_entropy": 0.52,
         "kullback_leibler_divergence": 0.02,
         "families": {
-            "Sunrhavirus": 1,
-            "Alpharhabdovirinae": 5,
-            "Betarhabdovirinae": 1,
-            "Rhabdoviridae": 2,
-            "Baculoviridae": 1
+            "Geminiviridae": 4
         },
         "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Ephemerovirus": 3,
-            "Ledantevirus": 1,
-            "Cytorhabdovirus": 1,
-            "Nucleorhabdovirus": 1,
-            "Vesiculovirus": 1,
-            "Betabaculovirus": 1,
-            "unclassified Rhabdoviridae": 1
-        }
-    },
-    {
-        "cluster": "60",
-        "names": [
-            "large tegument protein",
-            "hypothetical protein",
-            "orf39"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177216.1",
-                "name": "hypothetical protein",
-                "organism": "Colletotrichum higginsianum non-segmented dsRNA virus 1"
-            },
-            {
-                "accession": "YP_009186730.1",
-                "name": "orf39",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009207097.1",
-                "name": "very large tegument protein, partial",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227269.1",
-                "name": "large tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230166.1",
-                "name": "large tegument protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 5.0,
-        "alen": 2897,
-        "length": 1198,
-        "eff_nseq": 1.52,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.46,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Riboviria": 1,
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "dsRNA viruses": 1,
-            "Alphabaculovirus": 1,
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "61",
-        "names": [
-            "nucleocapsid protein",
-            "nucleoprotein",
-            "nonstructural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177597.1",
-                "name": "nucleocapsid protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009179207.1",
-                "name": "nucleoprotein",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009227244.1",
-                "name": "myristoylated tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230141.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009480341.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 535,
-        "length": 318,
-        "eff_nseq": 1.63,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Orthoparamyxovirinae": 1,
-            "Respirovirus": 1,
-            "Spinareovirinae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Morbillivirus": 1,
-            "Caprine respirovirus 3": 1,
-            "Fijivirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "62",
-        "names": [
-            "FP25K",
-            "fp/25k",
-            "gp37"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182151.1",
-                "name": "minor structural protein",
-                "organism": "Maize rough dwarf virus"
-            },
-            {
-                "accession": "YP_009182303.1",
-                "name": "FP25K",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186739.1",
-                "name": "fp/25k",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186743.1",
-                "name": "gp37",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230018.1",
-                "name": "fp 25k",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 938,
-        "length": 349,
-        "eff_nseq": 1.71,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2,
-            "Fijivirus": 1
+            "Begomovirus": 4
         }
     },
     {
         "cluster": "63",
         "names": [
-            "matrix protein",
-            "M"
+            "minor capsid protein",
+            "DNA packaging tegument protein",
+            "DNA packaging tegument protein UL25"
         ],
         "entries": [
             {
-                "accession": "YP_009176968.1",
-                "name": "M",
-                "organism": "Inhangapi virus"
+                "accession": "YP_009207085.1",
+                "name": "minor capsid protein",
+                "organism": "Hawaiian green turtle herpesvirus"
             },
             {
-                "accession": "YP_009177012.1",
-                "name": "M",
-                "organism": "Kumasi rhabdovirus"
+                "accession": "YP_009227258.1",
+                "name": "DNA packaging tegument protein",
+                "organism": "Macropodid alphaherpesvirus 1"
             },
             {
-                "accession": "YP_009177195.1",
-                "name": "matrix protein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177207.1",
-                "name": "matrix protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177241.1",
-                "name": "matrix protein",
-                "organism": "Adelaide River virus"
+                "accession": "YP_009230156.1",
+                "name": "DNA packaging tegument protein UL25",
+                "organism": "Leporid alphaherpesvirus 4"
             }
         ],
-        "count": 5.0,
-        "alen": 231,
-        "length": 217,
-        "eff_nseq": 1.33,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Alpharhabdovirinae": 4
-        },
-        "genera": {
-            "Ephemerovirus": 3,
-            "Ledantevirus": 1
-        }
-    },
-    {
-        "cluster": "64",
-        "names": [
-            "capsid protein",
-            "VP1",
-            "VP2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009215303.1",
-                "name": "capsid protein",
-                "organism": "Lagomorph bocaparvovirus 1"
-            },
-            {
-                "accession": "YP_009227293.1",
-                "name": "VP1",
-                "organism": "Rat bocavirus"
-            },
-            {
-                "accession": "YP_009227294.1",
-                "name": "VP2",
-                "organism": "Rat bocavirus"
-            },
-            {
-                "accession": "YP_009229910.1",
-                "name": "VP1 protein",
-                "organism": "Bat bocavirus"
-            },
-            {
-                "accession": "YP_009229911.1",
-                "name": "VP2 protein",
-                "organism": "Bat bocavirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 734,
-        "length": 707,
-        "eff_nseq": 0.62,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
+        "count": 3.0,
+        "alen": 595,
+        "length": 577,
+        "eff_nseq": 0.72,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
         "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.02,
+        "kullback_leibler_divergence": 0.01,
         "families": {
-            "Parvovirinae": 1,
-            "Bocaparvovirus": 4
+            "Alphaherpesvirinae": 3
         },
         "genera": {
-            "Bocaparvovirus": 1,
-            "Rodent bocaparvovirus 1": 2,
-            "unclassified Bocaparvovirus": 2
-        }
-    },
-    {
-        "cluster": "65",
-        "names": [
-            "polyprotein",
-            "orf14",
-            "HC-Pro"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175090.1",
-                "name": "polyprotein",
-                "organism": "Rice necrosis mosaic virus"
-            },
-            {
-                "accession": "YP_009186705.1",
-                "name": "orf14",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009221984.1",
-                "name": "HC-Pro",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009221988.1",
-                "name": "6K2 protein",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009229929.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 942,
-        "length": 332,
-        "eff_nseq": 1.85,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Potyviridae": 3,
-            "Baculoviridae": 2
-        },
-        "genera": {
-            "Bymovirus": 1,
-            "Alphabaculovirus": 1,
-            "Potyvirus": 2,
-            "Betabaculovirus": 1
+            "Scutavirus": 1,
+            "Simplexvirus": 2
         }
     },
     {
         "cluster": "66",
         "names": [
-            "phosphoprotein",
-            "hypothetical protein",
-            "ac150"
+            "movement protein",
+            "fgf-2"
         ],
         "entries": [
             {
-                "accession": "YP_009176973.1",
-                "name": "phosphoprotein",
-                "organism": "Datura yellow vein nucleorhabdovirus"
+                "accession": "YP_009229913.1",
+                "name": "movement protein",
+                "organism": "Currant virus A"
             },
             {
-                "accession": "YP_009182299.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186749.1",
-                "name": "ac150",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009227128.1",
-                "name": "glycoprotein precursor complex",
-                "organism": "Adana virus"
-            },
-            {
-                "accession": "YP_009480530.1",
-                "name": "glycoprotein precursor",
-                "organism": "Arrabida virus"
+                "accession": "YP_009230015.1",
+                "name": "fgf-2",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 5.0,
-        "alen": 1381,
-        "length": 1099,
-        "eff_nseq": 1.25,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.5,
+        "count": 2.0,
+        "alen": 505,
+        "length": 505,
+        "eff_nseq": 0.74,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.02,
         "families": {
-            "Rhabdoviridae": 1,
-            "Baculoviridae": 2,
-            "Phlebovirus": 2
+            "Trivirinae": 1,
+            "Baculoviridae": 1
         },
         "genera": {
-            "Nucleorhabdovirus": 1,
-            "Betabaculovirus": 1,
-            "Alphabaculovirus": 1,
-            "unclassified Phlebovirus": 1,
-            "Adana phlebovirus": 1
+            "Capillovirus": 1,
+            "Betabaculovirus": 1
         }
     },
     {
         "cluster": "67",
         "names": [
-            "p6.9",
-            "nonstructural protein",
-            "hypothetical protein ORF7"
+            "P24",
+            "p24"
         ],
         "entries": [
             {
-                "accession": "YP_009186774.1",
-                "name": "p6.9",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
+                "accession": "YP_009182258.1",
+                "name": "P24",
+                "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009199795.1",
-                "name": "hypothetical protein ORF7",
-                "organism": "BtRf-AlphaCoV/HuB2013"
-            },
-            {
-                "accession": "YP_009227285.1",
-                "name": "helicase primase subunit",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230187.1",
-                "name": "UL52 helicase-primase primase subunit",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009480339.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
+                "accession": "YP_009229971.1",
+                "name": "p24",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 5.0,
-        "alen": 1047,
-        "length": 767,
-        "eff_nseq": 1.53,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
+        "count": 2.0,
+        "alen": 168,
+        "length": 168,
+        "eff_nseq": 0.55,
+        "mean_entropy": 0.593,
+        "total_entropy": 1.19,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
         "families": {
-            "Baculoviridae": 1,
-            "Spinareovirinae": 1,
-            "Decacovirus": 1,
-            "Alphaherpesvirinae": 2
+            "Baculoviridae": 2
         },
         "genera": {
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1,
-            "Rhinolophus ferrumequinum alphacoronavirus HuB-2013": 1,
-            "Simplexvirus": 2
+            "Betabaculovirus": 2
         }
     },
     {
         "cluster": "68",
         "names": [
-            "38.7k",
+            "movement protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009175073.1",
+                "name": "movement protein",
+                "organism": "Melon chlorotic leaf curl virus-"
+            },
+            {
+                "accession": "YP_009175081.1",
+                "name": "movement protein",
+                "organism": "Melochia mosaic virus"
+            },
+            {
+                "accession": "YP_009175088.1",
+                "name": "movement protein",
+                "organism": "Melochia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009480523.1",
+                "name": "movement protein",
+                "organism": "Pavonia yellow mosaic virus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 293,
+        "length": 293,
+        "eff_nseq": 0.43,
+        "mean_entropy": 0.592,
+        "total_entropy": 2.37,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Geminiviridae": 4
+        },
+        "genera": {
+            "Begomovirus": 4
+        }
+    },
+    {
+        "cluster": "7",
+        "names": [
+            "RNA dependent RNA polymerase"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182160.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Botrytis cinerea mitovirus 2"
+            },
+            {
+                "accession": "YP_009182162.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Grapevine associated narnavirus-1"
+            },
+            {
+                "accession": "YP_009182163.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Botrytis cinerea mitovirus 4"
+            },
+            {
+                "accession": "YP_009182164.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Sclerotinia sclerotiorum mitovirus 3"
+            }
+        ],
+        "count": 4.0,
+        "alen": 801,
+        "length": 720,
+        "eff_nseq": 1.02,
+        "mean_entropy": 0.591,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Mitovirus": 3,
+            "Narnavirus": 1
+        },
+        "genera": {
+            "unclassified Mitovirus": 3,
+            "unclassified Narnavirus": 1
+        }
+    },
+    {
+        "cluster": "71",
+        "names": [
+            "VP3",
+            "VP2"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009220467.1",
+                "name": "VP3",
+                "organism": "Tupaia hepatovirus A"
+            },
+            {
+                "accession": "YP_009220468.1",
+                "name": "VP2",
+                "organism": "Tupaia hepatovirus A"
+            }
+        ],
+        "count": 2.0,
+        "alen": 257,
+        "length": 257,
+        "eff_nseq": 0.68,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Hepatovirus": 2
+        },
+        "genera": {
+            "unclassified Hepatovirus": 2
+        }
+    },
+    {
+        "cluster": "72",
+        "names": [
             "38.8K",
             "ac57"
         ],
@@ -9750,421 +6531,68 @@
                 "accession": "YP_009186735.1",
                 "name": "ac57",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186807.1",
-                "name": "orf116",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186813.1",
-                "name": "38.7k",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229972.1",
-                "name": "38.7k",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 5.0,
-        "alen": 956,
-        "length": 346,
-        "eff_nseq": 1.71,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.45,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 5
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 3
-        }
-    },
-    {
-        "cluster": "69",
-        "names": [
-            "ie-0",
-            "single-stranded DNA-binding protein",
-            "P1 Protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186708.1",
-                "name": "ie-0",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009207090.1",
-                "name": "single-stranded DNA-binding protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009221983.1",
-                "name": "P1 Protein",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009227262.1",
-                "name": "single stranded binding protein ICP8",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230160.1",
-                "name": "UL29 major DNA-binding protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 5.0,
-        "alen": 1328,
-        "length": 1077,
-        "eff_nseq": 1.13,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 3,
-            "Potyviridae": 1
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Scutavirus": 1,
-            "Potyvirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "7",
-        "names": [
-            "polymerase",
-            "5 protein",
-            "putative RNA-dependent RNA polymerase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177218.1",
-                "name": "polymerase",
-                "organism": "Suffolk virus"
-            },
-            {
-                "accession": "YP_009177226.1",
-                "name": "5 protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
-            {
-                "accession": "YP_009177701.1",
-                "name": "polymerase",
-                "organism": "Bole Tick Virus 3"
-            },
-            {
-                "accession": "YP_009177704.1",
-                "name": "polymerase",
-                "organism": "Changping Tick Virus 2"
-            },
-            {
-                "accession": "YP_009177707.1",
-                "name": "polymerase",
-                "organism": "Changping Tick Virus 3"
-            },
-            {
-                "accession": "YP_009177716.1",
-                "name": "polymerase",
-                "organism": "Tacheng Tick Virus 4"
-            },
-            {
-                "accession": "YP_009177717.1",
-                "name": "polymerase",
-                "organism": "Tacheng Tick Virus 5"
-            },
-            {
-                "accession": "YP_009177719.1",
-                "name": "polymerase",
-                "organism": "Wuhan Mosquito Virus 8"
-            },
-            {
-                "accession": "YP_009177722.1",
-                "name": "polymerase",
-                "organism": "Wuhan tick virus 2"
-            },
-            {
-                "accession": "YP_009182177.1",
-                "name": "putative RNA-dependent RNA polymerase",
-                "organism": "Imjin River virus 1"
-            },
-            {
-                "accession": "YP_009230202.1",
-                "name": "membrane protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 11.0,
-        "alen": 2303,
-        "length": 2164,
-        "eff_nseq": 1.55,
-        "mean_entropy": 0.59,
-        "total_entropy": 6.49,
-        "mean_positional_relative_entropy": 0.53,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Mivirus": 4,
-            "Betarhabdovirinae": 1,
-            "unclassified ssRNA viruses": 4,
-            "Rhabdoviridae": 1,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Suffolk mivirus": 1,
-            "Cytorhabdovirus": 1,
-            "unclassified ssRNA negative-strand viruses": 4,
-            "Argas mivirus": 1,
-            "Bole mivirus": 1,
-            "unclassified Rhabdoviridae": 1,
-            "Imjin mivirus": 1,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "70",
-        "names": [
-            "hypothetical protein",
-            "ep23",
-            "nonstructural protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182205.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182264.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186713.1",
-                "name": "ep23",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229926.1",
-                "name": "ie-1",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009480340.1",
-                "name": "nonstructural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 366,
-        "length": 196,
-        "eff_nseq": 1.49,
+        "count": 2.0,
+        "alen": 164,
+        "length": 164,
+        "eff_nseq": 0.73,
         "mean_entropy": 0.589,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1
-        }
-    },
-    {
-        "cluster": "71",
-        "names": [
-            "matrix protein",
-            "metalloproteinase (stromelysin-1-like)",
-            "chitinase"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176982.1",
-                "name": "matrix protein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009182238.1",
-                "name": "metalloproteinase (stromelysin-1-like)",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186745.1",
-                "name": "chitinase",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229958.1",
-                "name": "mp-nase",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009480345.1",
-                "name": "major outer structural protein",
-                "organism": "Maize rough dwarf virus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 690,
-        "length": 440,
-        "eff_nseq": 1.67,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Sunrhavirus": 1,
-            "Baculoviridae": 3,
-            "Spinareovirinae": 1
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "Fijivirus": 1
-        }
-    },
-    {
-        "cluster": "72",
-        "names": [
-            "p43",
-            "glycoprotein I",
-            "E protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186786.1",
-                "name": "p43",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009221999.1",
-                "name": "E protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009227225.1",
-                "name": "glycoprotein I",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230200.1",
-                "name": "virion glycoprotein I",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230204.1",
-                "name": "virion protein US10",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 5.0,
-        "alen": 503,
-        "length": 372,
-        "eff_nseq": 1.86,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
+        "total_entropy": 1.18,
         "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
+        "kullback_leibler_divergence": 0.04,
         "families": {
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 3,
-            "Kaftartevirus": 1
+            "Baculoviridae": 2
         },
         "genera": {
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 3,
-            "Thetaarterivirus kafuba": 1
+            "Betabaculovirus": 1,
+            "Alphabaculovirus": 1
         }
     },
     {
         "cluster": "73",
         "names": [
-            "odv-e25",
-            "delta protein",
-            "ODV-E25"
+            "DNA-ligase",
+            "ligase"
         ],
         "entries": [
             {
-                "accession": "YP_009177202.1",
-                "name": "delta protein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009182281.1",
-                "name": "ODV-E25",
+                "accession": "YP_009182307.1",
+                "name": "DNA-ligase",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009186769.1",
-                "name": "odv-e25",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186814.1",
-                "name": "ac19",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229992.1",
-                "name": "odv-e25",
+                "accession": "YP_009230017.1",
+                "name": "ligase",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 5.0,
-        "alen": 242,
-        "length": 218,
-        "eff_nseq": 1.2,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.96,
+        "count": 2.0,
+        "alen": 589,
+        "length": 589,
+        "eff_nseq": 0.47,
+        "mean_entropy": 0.586,
+        "total_entropy": 1.17,
         "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.03,
         "families": {
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 4
+            "Baculoviridae": 2
         },
         "genera": {
-            "Ephemerovirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
+            "Betabaculovirus": 2
         }
     },
     {
         "cluster": "74",
         "names": [
-            "gp41",
-            "M protein",
-            "GP41"
+            "GP41",
+            "gp41"
         ],
         "entries": [
-            {
-                "accession": "YP_009177228.1",
-                "name": "M protein",
-                "organism": "Barley yellow striate mosaic cytorhabdovirus"
-            },
             {
                 "accession": "YP_009182219.1",
                 "name": "GP41",
                 "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182231.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186759.1",
-                "name": "gp41",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
                 "accession": "YP_009230007.1",
@@ -10172,40 +6600,71 @@
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 5.0,
-        "alen": 417,
+        "count": 2.0,
+        "alen": 293,
         "length": 293,
-        "eff_nseq": 1.24,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
+        "eff_nseq": 0.46,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.03,
         "families": {
-            "Betarhabdovirinae": 1,
-            "Baculoviridae": 4
+            "Baculoviridae": 2
         },
         "genera": {
-            "Cytorhabdovirus": 1,
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
+            "Betabaculovirus": 2
         }
     },
     {
         "cluster": "75",
         "names": [
-            "hypothetical protein",
-            "orf5",
-            "tegument serine/threonine protein kinase"
+            "nuclear egress membrane protein",
+            "membrane-associated phosphoprotein"
         ],
         "entries": [
             {
-                "accession": "YP_009182287.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
+                "accession": "YP_009207095.1",
+                "name": "membrane-associated phosphoprotein",
+                "organism": "Hawaiian green turtle herpesvirus"
             },
             {
-                "accession": "YP_009186696.1",
-                "name": "orf5",
+                "accession": "YP_009227267.1",
+                "name": "nuclear egress membrane protein",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230164.1",
+                "name": "nuclear egress membrane protein",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 290,
+        "length": 276,
+        "eff_nseq": 0.95,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "77",
+        "names": [
+            "egt",
+            "tegument serine/threonine protein kinase",
+            "tegument serine/threonine protein kinase UL13"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009186810.1",
+                "name": "egt",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
@@ -10217,449 +6676,62 @@
                 "accession": "YP_009230143.1",
                 "name": "tegument serine/threonine protein kinase UL13",
                 "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230176.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
             }
         ],
-        "count": 5.0,
-        "alen": 549,
-        "length": 422,
-        "eff_nseq": 1.52,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.94,
+        "count": 3.0,
+        "alen": 607,
+        "length": 496,
+        "eff_nseq": 0.91,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
         "mean_positional_relative_entropy": 0.51,
         "kullback_leibler_divergence": 0.02,
         "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 1,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 3
-        }
-    },
-    {
-        "cluster": "76",
-        "names": [
-            "C protein",
-            "P40",
-            "p40"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177600.1",
-                "name": "C protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009182273.1",
-                "name": "P40",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186775.1",
-                "name": "p40",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186819.1",
-                "name": "orf128",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229986.1",
-                "name": "p40/c42",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 405,
-        "length": 361,
-        "eff_nseq": 1.31,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Orthoparamyxovirinae": 1,
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Morbillivirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "77",
-        "names": [
-            "pif-2",
-            "per os infectivity factor 2",
-            "VPg"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182240.1",
-                "name": "per os infectivity factor 2",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186804.1",
-                "name": "pif-2",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009221989.1",
-                "name": "VPg",
-                "organism": "Jasmine virus T"
-            },
-            {
-                "accession": "YP_009222003.1",
-                "name": "GP5 protein",
-                "organism": "Kafue kinda chacma baboon virus"
-            },
-            {
-                "accession": "YP_009229967.1",
-                "name": "pif-2",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 5.0,
-        "alen": 394,
-        "length": 308,
-        "eff_nseq": 1.27,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.94,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 3,
-            "Potyviridae": 1,
-            "Kaftartevirus": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "Potyvirus": 1,
-            "Thetaarterivirus kafuba": 1
-        }
-    },
-    {
-        "cluster": "78",
-        "names": [
-            "immediate early protein ICP0",
-            "hypothetical protein",
-            "orf75"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182241.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186766.1",
-                "name": "orf75",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009227214.1",
-                "name": "ubiquitin E3 ligase ICP0",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230128.1",
-                "name": "immediate early protein ICP0",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230192.1",
-                "name": "immediate early protein ICP0",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 5.0,
-        "alen": 620,
-        "length": 517,
-        "eff_nseq": 1.18,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.95,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 2,
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "Betabaculovirus": 1,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 3
-        }
-    },
-    {
-        "cluster": "79",
-        "names": [
-            "hypothetical protein",
-            "80 kDa protein",
-            "orf40"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182333.1",
-                "name": "80 kDa protein",
-                "organism": "Penicillium janczewskii chrysovirus 1"
-            },
-            {
-                "accession": "YP_009186731.1",
-                "name": "orf40",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009230129.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230191.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 823,
-        "length": 184,
-        "eff_nseq": 0.93,
-        "mean_entropy": 0.588,
-        "total_entropy": 2.35,
-        "mean_positional_relative_entropy": 0.41,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Chrysoviridae": 1,
             "Baculoviridae": 1,
             "Alphaherpesvirinae": 2
         },
         "genera": {
-            "Betachrysovirus": 1,
             "Alphabaculovirus": 1,
             "Simplexvirus": 2
         }
     },
     {
-        "cluster": "8",
+        "cluster": "78",
         "names": [
-            "polyprotein",
-            "70 kDa protein",
-            "lef-6"
+            "vp39",
+            "P13",
+            "VP39"
         ],
         "entries": [
             {
-                "accession": "YP_008999615.1",
-                "name": "p19 protein",
-                "organism": "Eggplant mottled crinkle virus"
-            },
-            {
-                "accession": "YP_009182334.1",
-                "name": "70 kDa protein",
-                "organism": "Penicillium janczewskii chrysovirus 1"
-            },
-            {
-                "accession": "YP_009186703.1",
-                "name": "lef-6",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186752.1",
-                "name": "lef-3",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186794.1",
-                "name": "ac117",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186809.1",
-                "name": "orf118",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009212849.1",
-                "name": "polyprotein",
-                "organism": "Hordeum vulgare alphaendornavirus"
-            },
-            {
-                "accession": "YP_009222598.1",
-                "name": "polyprotein",
-                "organism": "Cucumis melo alphaendornavirus"
-            },
-            {
-                "accession": "YP_009225663.1",
-                "name": "polyprotein",
-                "organism": "Erysiphe cichoracearum alphaendornavirus"
-            },
-            {
-                "accession": "YP_009230000.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 10.0,
-        "alen": 5157,
-        "length": 1789,
-        "eff_nseq": 3.85,
-        "mean_entropy": 0.59,
-        "total_entropy": 5.9,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Chrysoviridae": 1,
-            "Baculoviridae": 5,
-            "Procedovirinae": 1,
-            "Endornaviridae": 3
-        },
-        "genera": {
-            "Betachrysovirus": 1,
-            "Alphabaculovirus": 4,
-            "Tombusvirus": 1,
-            "Alphaendornavirus": 3,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "80",
-        "names": [
-            "major capsid protein",
-            "ICP34.5",
-            "fgf-2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227215.1",
-                "name": "ICP34.5",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009227252.1",
-                "name": "major capsid protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230015.1",
-                "name": "fgf-2",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230150.1",
-                "name": "major capsid protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 1387,
-        "length": 1020,
-        "eff_nseq": 1.33,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 3,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "Simplexvirus": 3,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "81",
-        "names": [
-            "VP2",
-            "structural protein",
-            "alpha 3 protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186687.1",
-                "name": "VP2",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009186688.1",
-                "name": "structural protein",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009204559.1",
-                "name": "alpha 3 protein",
-                "organism": "Fox fecal rhabdovirus"
-            },
-            {
-                "accession": "YP_009230146.1",
-                "name": "DNA packaging tegument protein UL17",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 414,
-        "length": 304,
-        "eff_nseq": 1.19,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.37,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Polyomaviridae": 2,
-            "Rhabdoviridae": 1,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Betapolyomavirus": 2,
-            "unclassified Rhabdoviridae": 1,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "82",
-        "names": [
-            "lef-2",
-            "late expression factor 2",
-            "bro-C"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182234.1",
-                "name": "late expression factor 2",
+                "accession": "YP_009182239.1",
+                "name": "P13",
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009186801.1",
-                "name": "lef-2",
+                "accession": "YP_009182285.1",
+                "name": "VP39",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186764.1",
+                "name": "vp39",
                 "organism": "Sucra jujuba nucleopolyhedrovirus"
             },
             {
-                "accession": "YP_009229940.1",
-                "name": "lef-2",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            },
-            {
-                "accession": "YP_009230005.1",
-                "name": "bro-C",
+                "accession": "YP_009229996.1",
+                "name": "vp39",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
         "count": 4.0,
-        "alen": 238,
-        "length": 167,
-        "eff_nseq": 1.36,
-        "mean_entropy": 0.591,
+        "alen": 357,
+        "length": 308,
+        "eff_nseq": 1.0,
+        "mean_entropy": 0.59,
         "total_entropy": 2.36,
         "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
+        "kullback_leibler_divergence": 0.03,
         "families": {
             "Baculoviridae": 4
         },
@@ -10669,61 +6741,267 @@
         }
     },
     {
-        "cluster": "83",
+        "cluster": "8",
+        "names": [
+            "replication-associated protein",
+            "2C",
+            "replication protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009220465.1",
+                "name": "2C",
+                "organism": "Tupaia hepatovirus A"
+            },
+            {
+                "accession": "YP_009226563.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular virus 2"
+            },
+            {
+                "accession": "YP_009226567.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular virus 4"
+            },
+            {
+                "accession": "YP_009226569.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular genome 1"
+            },
+            {
+                "accession": "YP_009226571.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular genome 3"
+            },
+            {
+                "accession": "YP_009226572.1",
+                "name": "replication-associated protein",
+                "organism": "Ctenophore-associated circular genome 4"
+            },
+            {
+                "accession": "YP_009230209.1",
+                "name": "replication protein",
+                "organism": "Bhindi yellow vein alphasatellite"
+            }
+        ],
+        "count": 7.0,
+        "alen": 428,
+        "length": 296,
+        "eff_nseq": 1.51,
+        "mean_entropy": 0.589,
+        "total_entropy": 4.12,
+        "mean_positional_relative_entropy": 0.47,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Hepatovirus": 1,
+            "unclassified DNA viruses": 2,
+            "DNA satellites": 3,
+            "Geminialphasatellitinae": 1
+        },
+        "genera": {
+            "unclassified Hepatovirus": 1,
+            "unclassified ssDNA viruses": 2,
+            "Single stranded DNA satellites": 3,
+            "unclassified Begomovirus-associated alphasatellites": 1
+        }
+    },
+    {
+        "cluster": "80",
+        "names": [
+            "DNA polymerase",
+            "dna polymerase",
+            "desmoplakin"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182295.1",
+                "name": "DNA polymerase",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186754.1",
+                "name": "dna polymerase",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009230026.1",
+                "name": "desmoplakin",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 1169,
+        "length": 1029,
+        "eff_nseq": 0.65,
+        "mean_entropy": 0.592,
+        "total_entropy": 1.78,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "81",
+        "names": [
+            "membrane-associated protein",
+            "nuclear protein UL24"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207084.1",
+                "name": "membrane-associated protein",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009230155.1",
+                "name": "nuclear protein UL24",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 2.0,
+        "alen": 318,
+        "length": 318,
+        "eff_nseq": 0.65,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
+        "families": {
+            "Alphaherpesvirinae": 2
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 1
+        }
+    },
+    {
+        "cluster": "82",
         "names": [
             "RNA-dependent RNA polymerase",
             "RNA dependent RNA polymerase",
+            "nonstructural protein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182167.1",
+                "name": "RNA-dependent RNA polymerase",
+                "organism": "Ustilaginoidea virens RNA virus 5"
+            },
+            {
+                "accession": "YP_009212848.1",
+                "name": "RNA dependent RNA polymerase",
+                "organism": "Penicillium aurantiogriseum totivirus 1"
+            },
+            {
+                "accession": "YP_009229915.1",
+                "name": "nonstructural protein",
+                "organism": "Piscine myocarditis-like virus"
+            },
+            {
+                "accession": "YP_009230208.1",
+                "name": "RdRp",
+                "organism": "Camponotus nipponicus virus"
+            }
+        ],
+        "count": 4.0,
+        "alen": 980,
+        "length": 868,
+        "eff_nseq": 1.42,
+        "mean_entropy": 0.591,
+        "total_entropy": 2.36,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Victorivirus": 1,
+            "Ghabrivirales": 3
+        },
+        "genera": {
+            "unclassified Victorivirus": 1,
+            "Totiviridae": 3
+        }
+    },
+    {
+        "cluster": "83",
+        "names": [
+            "transcriptional regulator ICP4",
             "hypothetical protein"
         ],
         "entries": [
             {
-                "accession": "YP_009177217.1",
-                "name": "RNA-dependent RNA polymerase",
-                "organism": "Colletotrichum higginsianum non-segmented dsRNA virus 1"
+                "accession": "YP_009230194.1",
+                "name": "transcriptional regulator ICP4",
+                "organism": "Leporid alphaherpesvirus 4"
             },
             {
-                "accession": "YP_009177606.1",
-                "name": "RNA dependent RNA polymerase",
-                "organism": "Rosellinia necatrix partitivirus 6"
-            },
-            {
-                "accession": "YP_009182211.1",
+                "accession": "YP_009230205.1",
                 "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009182336.1",
-                "name": "62 kDa protein",
-                "organism": "Penicillium aurantiogriseum partitivirus 1"
+                "organism": "Leporid alphaherpesvirus 4"
             }
         ],
-        "count": 4.0,
-        "alen": 782,
-        "length": 618,
-        "eff_nseq": 1.31,
+        "count": 2.0,
+        "alen": 927,
+        "length": 770,
+        "eff_nseq": 0.45,
         "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.06,
         "families": {
-            "Riboviria": 1,
-            "Betapartitivirus": 1,
-            "Baculoviridae": 1,
-            "Partitiviridae": 1
+            "Alphaherpesvirinae": 2
         },
         "genera": {
-            "dsRNA viruses": 1,
-            "unclassified Betapartitivirus": 1,
-            "Betabaculovirus": 1,
-            "unclassified Partitiviridae": 1
+            "Simplexvirus": 2
         }
     },
     {
-        "cluster": "84",
+        "cluster": "87",
+        "names": [
+            "lef-11",
+            "late expression factor 11"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009182250.1",
+                "name": "late expression factor 11",
+                "organism": "Diatraea saccharalis granulovirus"
+            },
+            {
+                "accession": "YP_009186719.1",
+                "name": "lef-11",
+                "organism": "Sucra jujuba nucleopolyhedrovirus"
+            },
+            {
+                "accession": "YP_009229948.1",
+                "name": "lef-11",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 126,
+        "length": 99,
+        "eff_nseq": 0.69,
+        "mean_entropy": 0.588,
+        "total_entropy": 1.76,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.05,
+        "families": {
+            "Baculoviridae": 3
+        },
+        "genera": {
+            "Betabaculovirus": 2,
+            "Alphabaculovirus": 1
+        }
+    },
+    {
+        "cluster": "88",
         "names": [
             "VP91",
-            "GP64",
-            "vp91"
+            "tlp20"
         ],
         "entries": [
             {
@@ -10732,39 +7010,213 @@
                 "organism": "Diatraea saccharalis granulovirus"
             },
             {
-                "accession": "YP_009182316.1",
-                "name": "GP64",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186762.1",
-                "name": "vp91",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
                 "accession": "YP_009230001.1",
                 "name": "tlp20",
                 "organism": "Cnaphalocrocis medinalis granulovirus"
             }
         ],
-        "count": 4.0,
-        "alen": 945,
-        "length": 580,
-        "eff_nseq": 1.03,
+        "count": 2.0,
+        "alen": 611,
+        "length": 611,
+        "eff_nseq": 0.51,
         "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.03,
+        "total_entropy": 1.18,
+        "mean_positional_relative_entropy": 0.51,
+        "kullback_leibler_divergence": 0.02,
         "families": {
-            "Baculoviridae": 4
+            "Baculoviridae": 2
         },
         "genera": {
-            "Betabaculovirus": 3,
-            "Alphabaculovirus": 1
+            "Betabaculovirus": 2
         }
     },
     {
-        "cluster": "85",
+        "cluster": "89",
+        "names": [
+            "DNA cleavage/packaging protein",
+            "DNA packaging terminase subunit 2",
+            "DNA packaging terminase subunit 2 UL28"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207089.1",
+                "name": "DNA cleavage/packaging protein",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009227261.1",
+                "name": "DNA packaging terminase subunit 2",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230159.1",
+                "name": "DNA packaging terminase subunit 2 UL28",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 798,
+        "length": 768,
+        "eff_nseq": 0.65,
+        "mean_entropy": 0.589,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "9",
+        "names": [
+            "transactivator protein",
+            "transcriptional activator protein",
+            "transactivation protein"
+        ],
+        "entries": [
+            {
+                "accession": "NP_835274.1",
+                "name": "transactivation protein",
+                "organism": "Melon chlorotic leaf curl virus-"
+            },
+            {
+                "accession": "YP_009175077.1",
+                "name": "transactivator protein",
+                "organism": "Melochia mosaic virus"
+            },
+            {
+                "accession": "YP_009175084.1",
+                "name": "transactivator protein",
+                "organism": "Melochia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009177712.1",
+                "name": "transcriptional activator protein",
+                "organism": "Andrographis yellow vein leaf curl virus"
+            },
+            {
+                "accession": "YP_009216262.1",
+                "name": "transcriptional activator protein",
+                "organism": "Okra leaf curl Oman virus"
+            },
+            {
+                "accession": "YP_009216585.1",
+                "name": "AC2",
+                "organism": "Pepper yellow leaf curl Thailand virus"
+            },
+            {
+                "accession": "YP_009226416.1",
+                "name": "transactivating protein",
+                "organism": "Pavonia yellow mosaic virus"
+            },
+            {
+                "accession": "YP_009226626.1",
+                "name": "C2",
+                "organism": "Turnip leaf roll virus"
+            }
+        ],
+        "count": 8.0,
+        "alen": 146,
+        "length": 134,
+        "eff_nseq": 0.95,
+        "mean_entropy": 0.591,
+        "total_entropy": 4.73,
+        "mean_positional_relative_entropy": 0.53,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Geminiviridae": 8
+        },
+        "genera": {
+            "Begomovirus": 7,
+            "Turncurtovirus": 1
+        }
+    },
+    {
+        "cluster": "92",
+        "names": [
+            "hypothetical protein",
+            "phosphoprotein"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009176979.1",
+                "name": "phosphoprotein",
+                "organism": "Walkabout Creek virus"
+            },
+            {
+                "accession": "YP_009229965.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            },
+            {
+                "accession": "YP_009230011.1",
+                "name": "hypothetical protein",
+                "organism": "Cnaphalocrocis medinalis granulovirus"
+            }
+        ],
+        "count": 3.0,
+        "alen": 408,
+        "length": 327,
+        "eff_nseq": 1.05,
+        "mean_entropy": 0.59,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.48,
+        "kullback_leibler_divergence": 0.03,
+        "families": {
+            "Sunrhavirus": 1,
+            "Baculoviridae": 2
+        },
+        "genera": {
+            "Walkabout sunrhavirus": 1,
+            "Betabaculovirus": 2
+        }
+    },
+    {
+        "cluster": "94",
+        "names": [
+            "virion membrane glycoprotein B",
+            "glycoprotein B",
+            "envelope glycoprotein B-1"
+        ],
+        "entries": [
+            {
+                "accession": "YP_009207088.1",
+                "name": "virion membrane glycoprotein B",
+                "organism": "Hawaiian green turtle herpesvirus"
+            },
+            {
+                "accession": "YP_009227260.1",
+                "name": "glycoprotein B",
+                "organism": "Macropodid alphaherpesvirus 1"
+            },
+            {
+                "accession": "YP_009230158.1",
+                "name": "envelope glycoprotein B-1",
+                "organism": "Leporid alphaherpesvirus 4"
+            }
+        ],
+        "count": 3.0,
+        "alen": 944,
+        "length": 870,
+        "eff_nseq": 0.64,
+        "mean_entropy": 0.591,
+        "total_entropy": 1.77,
+        "mean_positional_relative_entropy": 0.52,
+        "kullback_leibler_divergence": 0.01,
+        "families": {
+            "Alphaherpesvirinae": 3
+        },
+        "genera": {
+            "Scutavirus": 1,
+            "Simplexvirus": 2
+        }
+    },
+    {
+        "cluster": "97",
         "names": [
             "p33",
             "matrix protein",
@@ -10808,736 +7260,6 @@
             "Vesiculovirus": 1,
             "Betabaculovirus": 2,
             "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "86",
-        "names": [
-            "large protein",
-            "large polymerase subunit",
-            "glycoprotein precursor"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177604.1",
-                "name": "large protein",
-                "organism": "Phocine morbillivirus"
-            },
-            {
-                "accession": "YP_009179212.1",
-                "name": "large polymerase subunit",
-                "organism": "Caprine parainfluenza virus 3"
-            },
-            {
-                "accession": "YP_009227121.1",
-                "name": "glycoprotein precursor",
-                "organism": "Tofla virus"
-            },
-            {
-                "accession": "YP_009227218.1",
-                "name": "hypothetical protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            }
-        ],
-        "count": 4.0,
-        "alen": 2287,
-        "length": 1448,
-        "eff_nseq": 1.25,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Orthoparamyxovirinae": 1,
-            "Respirovirus": 1,
-            "Orthonairovirus": 1,
-            "Alphaherpesvirinae": 1
-        },
-        "genera": {
-            "Morbillivirus": 1,
-            "Caprine respirovirus 3": 1,
-            "unclassified Nairovirus": 1,
-            "Simplexvirus": 1
-        }
-    },
-    {
-        "cluster": "87",
-        "names": [
-            "47 kDa protein",
-            "DNA cleavage/packaging protein",
-            "DNA packaging terminase subunit 2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182331.1",
-                "name": "47 kDa protein",
-                "organism": "Penicillium aurantiogriseum partitivirus 1"
-            },
-            {
-                "accession": "YP_009207089.1",
-                "name": "DNA cleavage/packaging protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227261.1",
-                "name": "DNA packaging terminase subunit 2",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230159.1",
-                "name": "DNA packaging terminase subunit 2 UL28",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 809,
-        "length": 741,
-        "eff_nseq": 0.97,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Partitiviridae": 1,
-            "Alphaherpesvirinae": 3
-        },
-        "genera": {
-            "unclassified Partitiviridae": 1,
-            "Scutavirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "88",
-        "names": [
-            "F",
-            "hypothetical protein",
-            "efp"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182223.1",
-                "name": "F",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186806.1",
-                "name": "F",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229918.1",
-                "name": "hypothetical protein",
-                "organism": "Blackberry virus F"
-            },
-            {
-                "accession": "YP_009229964.1",
-                "name": "efp",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 710,
-        "length": 581,
-        "eff_nseq": 0.96,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Baculoviridae": 3,
-            "Caulimoviridae": 1
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1,
-            "Badnavirus": 1
-        }
-    },
-    {
-        "cluster": "89",
-        "names": [
-            "VP5 protein",
-            "L1",
-            "L2"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177607.1",
-                "name": "VP5 protein",
-                "organism": "Tasmanian aquabirnavirus"
-            },
-            {
-                "accession": "YP_009177730.1",
-                "name": "L1",
-                "organism": "Trichechus manatus papillomavirus 4"
-            },
-            {
-                "accession": "YP_009182328.1",
-                "name": "L2",
-                "organism": "Rattus norvegicus papillomavirus 3"
-            },
-            {
-                "accession": "YP_009229924.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 507,
-        "length": 243,
-        "eff_nseq": 1.14,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Aquabirnavirus": 1,
-            "Firstpapillomavirinae": 2,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "unclassified Aquabirnavirus": 1,
-            "Rhopapillomavirus": 1,
-            "Iotapapillomavirus": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "9",
-        "names": [
-            "glycoprotein",
-            "G",
-            "pAG1"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009176969.1",
-                "name": "G",
-                "organism": "Inhangapi virus"
-            },
-            {
-                "accession": "YP_009176970.1",
-                "name": "pAG1",
-                "organism": "Inhangapi virus"
-            },
-            {
-                "accession": "YP_009176984.1",
-                "name": "glycoprotein",
-                "organism": "Walkabout Creek virus"
-            },
-            {
-                "accession": "YP_009177013.1",
-                "name": "G",
-                "organism": "Kumasi rhabdovirus"
-            },
-            {
-                "accession": "YP_009177196.1",
-                "name": "glycoprotein",
-                "organism": "Koolpinyah virus"
-            },
-            {
-                "accession": "YP_009177208.1",
-                "name": "glycoprotein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009177242.1",
-                "name": "virion transmembrane glycoprotein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009177650.1",
-                "name": "glycoprotein",
-                "organism": "Cocal virus"
-            },
-            {
-                "accession": "YP_009204556.1",
-                "name": "glycoprotein",
-                "organism": "Fox fecal rhabdovirus"
-            }
-        ],
-        "count": 9.0,
-        "alen": 882,
-        "length": 578,
-        "eff_nseq": 2.98,
-        "mean_entropy": 0.59,
-        "total_entropy": 5.31,
-        "mean_positional_relative_entropy": 0.48,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Sunrhavirus": 1,
-            "Alpharhabdovirinae": 5,
-            "Rhabdoviridae": 1
-        },
-        "genera": {
-            "Walkabout sunrhavirus": 1,
-            "Ephemerovirus": 3,
-            "Ledantevirus": 1,
-            "Vesiculovirus": 1,
-            "unclassified Rhabdoviridae": 1
-        }
-    },
-    {
-        "cluster": "90",
-        "names": [
-            "transcriptional regulator ICP4",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009227217.1",
-                "name": "transcriptional regulator ICP4",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230194.1",
-                "name": "transcriptional regulator ICP4",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230205.1",
-                "name": "hypothetical protein",
-                "organism": "Leporid alphaherpesvirus 4"
-            },
-            {
-                "accession": "YP_009230206.1",
-                "name": "transcriptional regulator ICP4",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 1365,
-        "length": 819,
-        "eff_nseq": 0.88,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.37,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.04,
-        "families": {
-            "Alphaherpesvirinae": 4
-        },
-        "genera": {
-            "Simplexvirus": 4
-        }
-    },
-    {
-        "cluster": "91",
-        "names": [
-            "polymerase-associated protein",
-            "orf107",
-            "tegument protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177240.1",
-                "name": "polymerase-associated protein",
-                "organism": "Adelaide River virus"
-            },
-            {
-                "accession": "YP_009186798.1",
-                "name": "orf107",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009227270.1",
-                "name": "tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230167.1",
-                "name": "tegument protein UL37",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 1089,
-        "length": 484,
-        "eff_nseq": 1.26,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.47,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "92",
-        "names": [
-            "minor capsid protein",
-            "DNA packaging tegument protein",
-            "hypothetical protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009207085.1",
-                "name": "minor capsid protein",
-                "organism": "Hawaiian green turtle herpesvirus"
-            },
-            {
-                "accession": "YP_009227126.1",
-                "name": "hypothetical protein",
-                "organism": "Rosellinia necatrix megabirnavirus 2-W8"
-            },
-            {
-                "accession": "YP_009227258.1",
-                "name": "DNA packaging tegument protein",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230156.1",
-                "name": "DNA packaging tegument protein UL25",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 595,
-        "length": 551,
-        "eff_nseq": 1.04,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.37,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alphaherpesvirinae": 3,
-            "Megabirnavirus": 1
-        },
-        "genera": {
-            "Scutavirus": 1,
-            "Simplexvirus": 2,
-            "unclassified Megabirnavirus": 1
-        }
-    },
-    {
-        "cluster": "93",
-        "names": [
-            "VP3",
-            "capsid protein precursor",
-            "predicted structural polyprotein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009220467.1",
-                "name": "VP3",
-                "organism": "Tupaia hepatovirus A"
-            },
-            {
-                "accession": "YP_009221982.1",
-                "name": "capsid protein precursor",
-                "organism": "Goose dicistrovirus"
-            },
-            {
-                "accession": "YP_009227213.1",
-                "name": "predicted structural polyprotein",
-                "organism": "Delisea pulchra RNA virus"
-            },
-            {
-                "accession": "YP_009230029.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 1128,
-        "length": 882,
-        "eff_nseq": 1.36,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Hepatovirus": 1,
-            "Dicistroviridae": 1,
-            "Picornavirales": 1,
-            "Baculoviridae": 1
-        },
-        "genera": {
-            "unclassified Hepatovirus": 1,
-            "unclassified Dicistroviridae": 1,
-            "unclassified Picornavirales": 1,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "94",
-        "names": [
-            "lef-11",
-            "alpha2x protein",
-            "late expression factor 11"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177212.1",
-                "name": "alpha2x protein",
-                "organism": "Yata virus"
-            },
-            {
-                "accession": "YP_009182250.1",
-                "name": "late expression factor 11",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186719.1",
-                "name": "lef-11",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229948.1",
-                "name": "lef-11",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 125,
-        "length": 99,
-        "eff_nseq": 1.04,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 3
-        },
-        "genera": {
-            "Ephemerovirus": 1,
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "95",
-        "names": [
-            "p24",
-            "P24",
-            "orf109"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182258.1",
-                "name": "P24",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186799.1",
-                "name": "p24",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186800.1",
-                "name": "orf109",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229971.1",
-                "name": "p24",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 267,
-        "length": 157,
-        "eff_nseq": 1.02,
-        "mean_entropy": 0.589,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.49,
-        "kullback_leibler_divergence": 0.03,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
-        }
-    },
-    {
-        "cluster": "96",
-        "names": [
-            "parg",
-            "LTag",
-            "STag"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009186690.1",
-                "name": "LTag",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009186691.1",
-                "name": "STag",
-                "organism": "Pan troglodytes verus polyomavirus 8"
-            },
-            {
-                "accession": "YP_009186789.1",
-                "name": "parg",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229982.1",
-                "name": "hypothetical protein",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 705,
-        "length": 563,
-        "eff_nseq": 1.38,
-        "mean_entropy": 0.591,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.02,
-        "families": {
-            "Baculoviridae": 2,
-            "Polyomaviridae": 2
-        },
-        "genera": {
-            "Alphabaculovirus": 1,
-            "Betapolyomavirus": 2,
-            "Betabaculovirus": 1
-        }
-    },
-    {
-        "cluster": "97",
-        "names": [
-            "movement protein"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009175073.1",
-                "name": "movement protein",
-                "organism": "Melon chlorotic leaf curl virus-"
-            },
-            {
-                "accession": "YP_009175081.1",
-                "name": "movement protein",
-                "organism": "Melochia mosaic virus"
-            },
-            {
-                "accession": "YP_009175088.1",
-                "name": "movement protein",
-                "organism": "Melochia yellow mosaic virus"
-            },
-            {
-                "accession": "YP_009480523.1",
-                "name": "movement protein",
-                "organism": "Pavonia yellow mosaic virus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 293,
-        "length": 293,
-        "eff_nseq": 0.43,
-        "mean_entropy": 0.592,
-        "total_entropy": 2.37,
-        "mean_positional_relative_entropy": 0.52,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Geminiviridae": 4
-        },
-        "genera": {
-            "Begomovirus": 4
-        }
-    },
-    {
-        "cluster": "98",
-        "names": [
-            "helicase-primase helicase subunit",
-            "hypothetical protein 3",
-            "lef-12"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009177010.1",
-                "name": "hypothetical protein 3",
-                "organism": "Kumasi rhabdovirus"
-            },
-            {
-                "accession": "YP_009186723.1",
-                "name": "lef-12",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009227238.1",
-                "name": "helicase-primase helicase subunit",
-                "organism": "Macropodid alphaherpesvirus 1"
-            },
-            {
-                "accession": "YP_009230135.1",
-                "name": "helicase-primase helicase subunit",
-                "organism": "Leporid alphaherpesvirus 4"
-            }
-        ],
-        "count": 4.0,
-        "alen": 896,
-        "length": 859,
-        "eff_nseq": 0.82,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.51,
-        "kullback_leibler_divergence": 0.01,
-        "families": {
-            "Alpharhabdovirinae": 1,
-            "Baculoviridae": 1,
-            "Alphaherpesvirinae": 2
-        },
-        "genera": {
-            "Ledantevirus": 1,
-            "Alphabaculovirus": 1,
-            "Simplexvirus": 2
-        }
-    },
-    {
-        "cluster": "99",
-        "names": [
-            "hypothetical protein",
-            "bro-1",
-            "pkip"
-        ],
-        "entries": [
-            {
-                "accession": "YP_009182268.1",
-                "name": "hypothetical protein",
-                "organism": "Diatraea saccharalis granulovirus"
-            },
-            {
-                "accession": "YP_009186698.1",
-                "name": "bro-1",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009186802.1",
-                "name": "pkip",
-                "organism": "Sucra jujuba nucleopolyhedrovirus"
-            },
-            {
-                "accession": "YP_009229981.1",
-                "name": "dnapol",
-                "organism": "Cnaphalocrocis medinalis granulovirus"
-            }
-        ],
-        "count": 4.0,
-        "alen": 175,
-        "length": 125,
-        "eff_nseq": 1.24,
-        "mean_entropy": 0.59,
-        "total_entropy": 2.36,
-        "mean_positional_relative_entropy": 0.5,
-        "kullback_leibler_divergence": 0.05,
-        "families": {
-            "Baculoviridae": 4
-        },
-        "genera": {
-            "Betabaculovirus": 2,
-            "Alphabaculovirus": 2
         }
     }
 ]

--- a/virtool_cli/vfam.py
+++ b/virtool_cli/vfam.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from virtool_cli.vfam_curate import get_input_paths, group_input_paths, write_curated_recs, remove_dupes, get_taxonomy
+from virtool_cli.vfam_curate import get_input_paths, group_input_paths, write_curated_recs, remove_dupes, \
+    get_taxonomy, write_no_dupes
 from virtool_cli.vfam_collapse import generate_clusters, write_rmv_polyproteins, blast_all_by_all
 from virtool_cli.vfam_polyprotein import find_polyproteins
 from virtool_cli.vfam_markov import blast_to_mcl, mcl_to_fasta
@@ -27,9 +28,11 @@ def run(src_path,
 
     no_dupes = remove_dupes(records, sequence_min_length)
 
-    taxonomy_records = get_taxonomy(no_dupes)
+    no_dupes_path = write_no_dupes(no_dupes, output, prefix)
 
-    curated_recs = write_curated_recs(no_dupes, output, list(taxonomy_records.keys()), prefix)
+    taxonomy_records = get_taxonomy(no_dupes_path)
+
+    curated_recs = write_curated_recs(no_dupes_path, list(taxonomy_records.keys()), prefix)
 
     cd_hit_result = generate_clusters(curated_recs, fraction_id, fraction_coverage, prefix)
 

--- a/virtool_cli/vfam.py
+++ b/virtool_cli/vfam.py
@@ -36,7 +36,7 @@ def run(
 
     curated_recs = write_curated_recs(no_dupes_path, list(taxonomy_records.keys()), prefix)
 
-    cd_hit_result = generate_clusters(curated_recs, fraction_id, fraction_coverage, prefix)
+    cd_hit_result_path = generate_clusters(curated_recs, fraction_id, fraction_coverage, prefix)
 
     if no_named_polyproteins:
         cd_hit_result_path = write_rmv_polyproteins(cd_hit_result_path, prefix)

--- a/virtool_cli/vfam.py
+++ b/virtool_cli/vfam.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from virtool_cli.vfam_curate import get_input_paths, group_input_paths, write_curated_recs
+from virtool_cli.vfam_curate import get_input_paths, group_input_paths, write_curated_recs, remove_dupes, get_taxonomy
 from virtool_cli.vfam_collapse import generate_clusters, write_rmv_polyproteins, blast_all_by_all
 from virtool_cli.vfam_polyprotein import find_polyproteins
 from virtool_cli.vfam_markov import blast_to_mcl, mcl_to_fasta
@@ -15,9 +15,13 @@ def run(src_path, output, prefix, sequence_min_length, no_named_phages, fraction
 
     records = group_input_paths(input_paths, no_named_phages)
 
-    no_dupes = write_curated_recs(records, output, sequence_min_length, prefix)
+    no_dupes = remove_dupes(records, sequence_min_length)
 
-    cd_hit_result = generate_clusters(no_dupes, fraction_id, prefix, fraction_coverage)
+    taxonomy_records = get_taxonomy(no_dupes)
+
+    curated_recs = write_curated_recs(no_dupes, output, list(taxonomy_records.keys()), prefix)
+
+    cd_hit_result = generate_clusters(curated_recs, fraction_id, prefix, fraction_coverage)
 
     if no_named_polyproteins:
         cd_hit_result = write_rmv_polyproteins(cd_hit_result, prefix)

--- a/virtool_cli/vfam.py
+++ b/virtool_cli/vfam.py
@@ -8,8 +8,18 @@ from virtool_cli.vfam_msa import batch_muscle_call, batch_hmm_call, concatenate_
 from virtool_cli.vfam_annotation import get_json_from_clusters
 
 
-def run(src_path, output, prefix, sequence_min_length, no_named_phages, fraction_coverage, fraction_id, num_cores,
-        no_named_polyproteins, inflation_num, coverage_check, min_sequences):
+def run(src_path,
+        output,
+        prefix,
+        sequence_min_length,
+        no_named_phages,
+        fraction_coverage,
+        fraction_id,
+        num_cores,
+        no_named_polyproteins,
+        inflation_num,
+        coverage_check,
+        min_sequences):
     """Dictates workflow for vfam pipeline."""
     input_paths = get_input_paths(Path(src_path))
 
@@ -21,7 +31,7 @@ def run(src_path, output, prefix, sequence_min_length, no_named_phages, fraction
 
     curated_recs = write_curated_recs(no_dupes, output, list(taxonomy_records.keys()), prefix)
 
-    cd_hit_result = generate_clusters(curated_recs, fraction_id, prefix, fraction_coverage)
+    cd_hit_result = generate_clusters(curated_recs, fraction_id, fraction_coverage, prefix)
 
     if no_named_polyproteins:
         cd_hit_result = write_rmv_polyproteins(cd_hit_result, prefix)
@@ -45,11 +55,4 @@ def run(src_path, output, prefix, sequence_min_length, no_named_phages, fraction
 
     concatenate_hmms(hmm_files, output, prefix)
 
-    get_json_from_clusters(fasta_files, output)
-
-
-
-
-
-
-
+    get_json_from_clusters(fasta_files, taxonomy_records, output)

--- a/virtool_cli/vfam_annotation.py
+++ b/virtool_cli/vfam_annotation.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Tuple, List
 from urllib.error import HTTPError
 from Bio import Entrez
-from Bio import GenBank, SeqIO
+from Bio import SeqIO
 
 
 def get_taxonomy(seq_ids: List[str]) -> Tuple[dict, dict]:
@@ -25,15 +25,16 @@ def get_taxonomy(seq_ids: List[str]) -> Tuple[dict, dict]:
     for seq_id in seq_ids:
         try:
             handle = Entrez.efetch(db="protein", id=seq_id, rettype="gb", retmode="text")
-            for record in GenBank.parse(handle):
+            for record in SeqIO.parse(handle, "genbank"):
+                taxonomy = record.annotations["taxonomy"]
 
-                family = record.taxonomy[-2]
+                family = taxonomy[-2]
                 if family.lower() == "viruses":
                     family = "None"
 
                 families[family] += 1
 
-                genus = record.taxonomy[-1]
+                genus = taxonomy[-1]
                 if genus.lower() == "unclassified viruses":
                     genus = "None"
 

--- a/virtool_cli/vfam_annotation.py
+++ b/virtool_cli/vfam_annotation.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Tuple, List
 from Bio import SeqIO
+from virtool_cli.vfam_console import console
 
 
 def get_taxonomy(seq_ids: List[str], taxonomy_records: dict) -> Tuple[dict, dict]:

--- a/virtool_cli/vfam_collapse.py
+++ b/virtool_cli/vfam_collapse.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from Bio import SeqIO
 
 
-def generate_clusters(curated_fasta_path: Path, fraction_id: float, prefix=None, fraction_cov=None) -> Path:
+def generate_clusters(curated_fasta_path: Path, fraction_id: float, fraction_cov=None, prefix=None) -> Path:
     """
     Takes in path to a FASTA file, minimum fraction ID, minimum fraction coverage and calls CD-HIT to cluster data.
 

--- a/virtool_cli/vfam_curate.py
+++ b/virtool_cli/vfam_curate.py
@@ -1,6 +1,7 @@
 import sys
+from urllib.error import HTTPError
 
-from Bio import SeqIO
+from Bio import SeqIO, Entrez
 from pathlib import Path
 from typing import List
 
@@ -48,14 +49,36 @@ def remove_dupes(records: iter, sequence_min_length: int) -> list:
     :param sequence_min_length: minimum length of sequence to be included in output
     """
     record_seqs = list()
-
+    no_dupes = list()
     for record in records:
         if record.seq not in record_seqs and len(record.seq) > sequence_min_length:
             record_seqs.append(record.seq)
-            yield record
+            no_dupes.append(record)
+    return no_dupes
 
 
-def write_curated_recs(records: iter, output: Path, sequence_min_length: int, prefix=None) -> Path:
+def get_taxonomy(records: iter):
+    """
+   Makes calls to NCBI database using Bio.Entrez to gather taxonomic information for each record.
+
+   If record isn't found in NCBI, record isn't included in output.
+
+   :param records: list of records from group_input_paths() step.
+   :return: record_taxonomy, a dictionary containing {record ID: taxonomy} pairs
+   """
+    record_taxonomy = dict()
+    for record in records:
+        try:
+            handle = Entrez.efetch(db="protein", id=record.id, rettype="gb", retmode="text")
+            for seq_record in SeqIO.parse(handle, "genbank"):
+                record_taxonomy[seq_record.id] = seq_record.annotations["taxonomy"]
+
+        except (HTTPError, AttributeError):
+            continue
+    return record_taxonomy
+
+
+def write_curated_recs(records: iter, output: Path, taxonomy_ids, prefix=None) -> Path:
     """
     Removes duplicates in no_phages list, writes all records in list to output.
 
@@ -63,8 +86,8 @@ def write_curated_recs(records: iter, output: Path, sequence_min_length: int, pr
 
     :param records: list of records from all protein files without keyword "phage"
     :param output: Path to output directory for profile HMMs and intermediate files
+    :param taxonomy_ids: list of record IDs for which taxonomy was found
     :param prefix: Prefix for intermediate and result files
-    :param sequence_min_length: Minimum sequence length for a record to be included in the input
     :return: Path to curated FASTA file without repeats or phages
     """
     output_dir = output / Path("intermediate_files")
@@ -75,8 +98,8 @@ def write_curated_recs(records: iter, output: Path, sequence_min_length: int, pr
     output_name = "curated_records.faa"
     if prefix:
         output_name = f"{prefix}_{output_name}"
-
     output_path = output_dir / Path(output_name)
-    SeqIO.write(remove_dupes(records, sequence_min_length), Path(output_path), "fasta")
+
+    SeqIO.write((record for record in records if record.id in taxonomy_ids), Path(output_path), "fasta")
 
     return output_path

--- a/virtool_cli/vfam_curate.py
+++ b/virtool_cli/vfam_curate.py
@@ -47,6 +47,7 @@ def remove_dupes(records: iter, sequence_min_length: int) -> list:
 
     :param records: iterable of records gathered in group_input_paths()
     :param sequence_min_length: minimum length of sequence to be included in output
+    :return: no_dupes, a list of filtered records
     """
     record_seqs = list()
     no_dupes = list()
@@ -57,14 +58,14 @@ def remove_dupes(records: iter, sequence_min_length: int) -> list:
     return no_dupes
 
 
-def get_taxonomy(records: iter):
+def get_taxonomy(records: list):
     """
    Makes calls to NCBI database using Bio.Entrez to gather taxonomic information for each record.
 
    If record isn't found in NCBI, record isn't included in output.
 
    :param records: list of records from group_input_paths() step.
-   :return: record_taxonomy, a dictionary containing {record ID: taxonomy} pairs
+   :return: record_taxonomy, a dictionary containing {record ID: [family, genus]} pairs
    """
     record_taxonomy = dict()
     for record in records:

--- a/virtool_cli/vfam_curate.py
+++ b/virtool_cli/vfam_curate.py
@@ -43,7 +43,7 @@ def group_input_paths(input_paths: List[Path], no_named_phages: bool) -> list:
 
 def remove_dupes(records: iter, sequence_min_length: int) -> list:
     """
-    Iterates through records and yields record if sequence isn't in record_seqs and is longer than sequence_min_length.
+    Iterates through records and filters out repeated records and sequences shorter than sequence_min_length.
 
     :param records: iterable of records gathered in group_input_paths()
     :param sequence_min_length: minimum length of sequence to be included in output
@@ -71,18 +71,16 @@ def get_taxonomy(records: iter):
         try:
             handle = Entrez.efetch(db="protein", id=record.id, rettype="gb", retmode="text")
             for seq_record in SeqIO.parse(handle, "genbank"):
-                record_taxonomy[seq_record.id] = seq_record.annotations["taxonomy"]
+                record_taxonomy[seq_record.id] = seq_record.annotations["taxonomy"][-2:]
 
         except (HTTPError, AttributeError):
             continue
     return record_taxonomy
 
 
-def write_curated_recs(records: iter, output: Path, taxonomy_ids, prefix=None) -> Path:
+def write_curated_recs(records: iter, output: Path, taxonomy_ids: List[str], prefix=None) -> Path:
     """
-    Removes duplicates in no_phages list, writes all records in list to output.
-
-    Verifies length of each sequence is longer than SEQUENCE_MIN_LENGTH.
+    Writes filtered records to output if taxonomic information was found for the record in get_taxonomy().
 
     :param records: list of records from all protein files without keyword "phage"
     :param output: Path to output directory for profile HMMs and intermediate files

--- a/virtool_cli/vfam_markov.py
+++ b/virtool_cli/vfam_markov.py
@@ -112,11 +112,11 @@ def mcl_to_fasta(mcl_path: Path, clustered_fasta_path: Path, prefix=None) -> Lis
 
             for record_id in line.strip().split("\t"):
                 mcl_path_dict[record_id] = fasta_path / Path(fasta_name)
+                open(mcl_path_dict[record_id], "w").close()
 
     for record in SeqIO.parse(clustered_fasta_path, "fasta"):
 
         if record.id in mcl_path_dict:
-
             with mcl_path_dict[record.id].open("a") as fasta_path:
                 SeqIO.write(record, fasta_path, "fasta")
 


### PR DESCRIPTION
Move collection of protein taxonomic information to the beginning of the workflow when the FASTA files are  processed. Exclude any records that can't be found in NCBI protein database.