### PR TITLE
Remove Deepsource coverage analyzer

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -3,7 +3,3 @@ version = 1
 [[analyzers]]
 name = "python"
 enabled = true
-
-[[analyzers]]
-name = "test-coverage"
-enabled = true


### PR DESCRIPTION
Stop analyzing test coverage. We are no longer tracking test coverage.