### PR TITLE
feat: Fetched sequence caching

### DIFF
--- a/assets/github/workflows/call_add_accessions.yml
+++ b/assets/github/workflows/call_add_accessions.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        required: true
-        default: '2.0.0a5'
+        type: string
 
       otu-path:
         required: true
@@ -21,7 +20,6 @@ on:
   workflow_call:
     inputs:
       version:
-        default: '2.0.0a5'
         type: string
 
       otu-path:
@@ -57,8 +55,9 @@ jobs:
           python-version: '3.10'
                 
       - name: Install virtool-cli
-        run: pip install virtool-cli==$VERSION
+        run: pip install virtool-cli $PIP_FLAGS
         env:
+          PIP_FLAGS: --pre
           VERSION: ${{ inputs.version }}
 
       - name: Set OTU id

--- a/assets/github/workflows/call_add_otu.yml
+++ b/assets/github/workflows/call_add_otu.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        required: true
-        default: '2.0.0a5'
+        type: string
 
       taxon-id:
         required: true
@@ -21,7 +20,6 @@ on:
   workflow_call:
     inputs:
       version:
-        default: '2.0.0a5'
         type: string
 
       taxon-id:
@@ -57,8 +55,9 @@ jobs:
           python-version: '3.10'
                 
       - name: Install virtool-cli
-        run: pip install virtool-cli==$VERSION
+        run: pip install virtool-cli $PIP_FLAGS
         env:
+          PIP_FLAGS: --pre
           VERSION: ${{ inputs.version }}
       
       - name: Set date for branch naming

--- a/assets/github/workflows/direct_update_ref.yml
+++ b/assets/github/workflows/direct_update_ref.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        required: true
-        default: '2.0.0a5'
+        type: string
       suffix:
         required: false
         default: ''
@@ -63,8 +62,9 @@ jobs:
           python-version: '3.10'
           
       - name: Install virtool-cli
-        run: pip install virtool-cli==$VERSION
+        run: pip install virtool-cli $PIP_FLAGS
         env:
+          PIP_FLAGS: --pre
           VERSION: ${{ inputs.version }}
       
       - name: Run update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "virtool-cli"
-version = "2.0.0-alpha.5"
+version = "2.0.0-alpha.9"
 authors = [
     "Ian Boyes <igboyes@gmail.com>",
     "Jake Alexander",

--- a/tests/test_utils_ncbi.py
+++ b/tests/test_utils_ncbi.py
@@ -19,6 +19,7 @@ async def test_utils_request_linked_accessions(index):
         assert type(accession) == str
 
 
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.parametrize("index", [0, 1, 2])
 async def test_utils_fetch_taxonomy_rank(index):

--- a/virtool_cli/add/add_otu.py
+++ b/virtool_cli/add/add_otu.py
@@ -4,7 +4,7 @@ import asyncio
 import structlog
 from urllib.error import HTTPError
 
-from virtool_cli.utils.logging import DEFAULT_LOGGER, DEBUG_LOGGER
+from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import is_v1, generate_otu_dirname, get_unique_otu_ids
 from virtool_cli.utils.id_generator import generate_unique_ids
 from virtool_cli.utils.ncbi import fetch_taxonomy_record
@@ -29,7 +29,7 @@ def run(
     :param src_path: Path to a reference directory
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(src=str(src_path))
 
     if is_v1(src_path):

--- a/virtool_cli/check/check_otu.py
+++ b/virtool_cli/check/check_otu.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import structlog
-from virtool_cli.utils.logging import DEBUG_LOGGER, DEFAULT_LOGGER
+
+from virtool_cli.utils.logging import configure_logger
 from virtool_cli.check.checkup import check_otu
 
 base_logger = structlog.get_logger()
@@ -13,7 +14,7 @@ def run(otu_path: Path, debugging: bool = False):
     :param otu_path: Path to an OTU directory
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(otu_path=str(otu_path), verbose=debugging)
 
     logger.debug("Debug flag is enabled")

--- a/virtool_cli/check/check_reference.py
+++ b/virtool_cli/check/check_reference.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 import structlog
 
+from virtool_cli.utils.logging import configure_logger
 from virtool_cli.check.checkup import check_otu
-from virtool_cli.utils.logging import DEBUG_LOGGER, DEFAULT_LOGGER
 from virtool_cli.utils.reference import get_otu_paths
 
 base_logger = structlog.get_logger()
@@ -15,7 +15,7 @@ def run(src_path: Path, debugging: bool = False):
     :param src_path: Path to a given reference directory
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(src=str(src_path), verbose=debugging)
 
     logger.debug("Debug flag is enabled")

--- a/virtool_cli/divide.py
+++ b/virtool_cli/divide.py
@@ -5,7 +5,7 @@ import shutil
 import aiofiles
 import structlog
 
-from virtool_cli.utils.logging import DEBUG_LOGGER, DEFAULT_LOGGER
+from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import generate_otu_dirname
 
 base_logger = structlog.get_logger()
@@ -33,7 +33,7 @@ def run(reference_path: Path, output_path: Path, debugging: bool = False):
     :param output_path: Path to the where the src tree should be generated
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(reference=str(reference_path), output=str(output_path))
 
     logger.info(f"Dividing {output_path.name} into {reference_path.name}...")

--- a/virtool_cli/init.py
+++ b/virtool_cli/init.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from shutil import copytree
 import structlog
-from virtool_cli.utils.logging import DEFAULT_LOGGER, DEBUG_LOGGER
+from virtool_cli.utils.logging import configure_logger
 
 base_logger = structlog.get_logger()
 
@@ -14,7 +14,7 @@ def run(repo_path: Path, debugging: bool = False):
     :param repo_path: Path to repository src directory
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(repo=str(repo_path))
 
     try:

--- a/virtool_cli/migrate.py
+++ b/virtool_cli/migrate.py
@@ -3,7 +3,7 @@ import asyncio
 import structlog
 import json
 
-from virtool_cli.utils.logging import DEFAULT_LOGGER, DEBUG_LOGGER
+from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import generate_otu_dirname, is_v1
 from virtool_cli.utils.storage import read_otu
 
@@ -15,7 +15,7 @@ def run(src_path: Path, debugging: bool = False):
     :param src_path: Path to a src database directory
     :param debugging: Enables verbose logs for debugging purposes
     """
-    structlog.configure(wrapper_class=DEBUG_LOGGER if debugging else DEFAULT_LOGGER)
+    configure_logger(debugging)
     logger = base_logger.bind(src_path=str(src_path))
 
     if not is_v1(src_path):

--- a/virtool_cli/migrate.py
+++ b/virtool_cli/migrate.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import asyncio
 import structlog
+import json
 
 from virtool_cli.utils.logging import DEFAULT_LOGGER, DEBUG_LOGGER
 from virtool_cli.utils.reference import generate_otu_dirname, is_v1
@@ -49,6 +50,8 @@ async def flatten_src(src_path: Path):
         )
 
         for otu_path in otu_paths:
+            init_exclusions(otu_path)
+
             otu = await read_otu(otu_path)
             new_name = generate_otu_dirname(otu.get("name"), otu.get("_id"))
             new_path = src_path / new_name
@@ -68,3 +71,8 @@ async def flatten_src(src_path: Path):
         except Exception as e:
             alpha_logger.error("Bin deletion failed")
             alpha_logger.exception(e)
+
+
+def init_exclusions(otu_path):
+    with open(otu_path / "exclusions.json", "w") as f:
+        json.dump([], f, indent=4, sort_keys=True)

--- a/virtool_cli/update/cli.py
+++ b/virtool_cli/update/cli.py
@@ -21,12 +21,18 @@ def update():
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a reference directory",
 )
+@click.option(
+    "--filter",
+    default="*",
+    type=str,
+    help="entry point for glob filter",
+)
 @click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
 @click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
-def reference(src_path, evaluate, debug):
+def reference(src_path, filter, evaluate, debug):
     """Fetch new sequences and isolates for all OTU in a given reference directory."""
     try:
-        run_update_all(src_path, auto_evaluate=evaluate, debugging=debug)
+        run_update_all(src_path, filter, auto_evaluate=evaluate, debugging=debug)
     except (FileNotFoundError, NotADirectoryError) as e:
         click.echo("Not a valid reference directory", err=True)
 

--- a/virtool_cli/update/cli.py
+++ b/virtool_cli/update/cli.py
@@ -3,6 +3,7 @@ import click
 
 from virtool_cli.update.update_ref import run as run_update_all
 from virtool_cli.update.update_otu import run as run_update_single
+from virtool_cli.update.uncache import run as run_update_uncache
 
 
 @click.group("update")
@@ -57,6 +58,31 @@ def otu(otu_path, evaluate, dry, debug):
             otu_path, auto_evaluate=evaluate, dry_run=dry, debugging=debug
         )
 
+    except (FileNotFoundError, NotADirectoryError) as e:
+        click.echo("Not a valid reference directory", err=True)
+
+
+@update.command()
+@click.option(
+    "-cache",
+    "--cache_path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="the path to a cache directory",
+)
+@click.option(
+    "-src",
+    "--src_path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="the path to a reference directory",
+)
+@click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
+@click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
+def uncache(cache_path, src_path, evaluate, debug):
+    """Fetch new sequences and isolates for all OTU in a given reference directory."""
+    try:
+        run_update_uncache(cache_path, src_path, auto_evaluate=evaluate, debugging=debug)
     except (FileNotFoundError, NotADirectoryError) as e:
         click.echo("Not a valid reference directory", err=True)
 

--- a/virtool_cli/update/cli.py
+++ b/virtool_cli/update/cli.py
@@ -27,12 +27,13 @@ def update():
     type=str,
     help="entry point for glob filter",
 )
+@click.option("--dry/--not-dry", default=False, help="Write to cache instead of reference")
 @click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
 @click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
-def reference(src_path, filter, evaluate, debug):
+def reference(src_path, filter, evaluate, dry, debug):
     """Fetch new sequences and isolates for all OTU in a given reference directory."""
     try:
-        run_update_all(src_path, filter, auto_evaluate=evaluate, debugging=debug)
+        run_update_all(src_path, filter, auto_evaluate=evaluate, dry_run=dry, debugging=debug)
     except (FileNotFoundError, NotADirectoryError) as e:
         click.echo("Not a valid reference directory", err=True)
 
@@ -45,14 +46,15 @@ def reference(src_path, filter, evaluate, debug):
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a single OTU directory",
 )
+@click.option("--dry/--not-dry", default=False, help="Write to cache instead of reference")
 @click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
 @click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
-def otu(otu_path, evaluate, debug):
+def otu(otu_path, evaluate, dry, debug):
     """Fetch new sequences and isolates for a given OTU directory."""
 
     try:
         run_update_single(
-            otu_path, auto_evaluate=evaluate, debugging=debug
+            otu_path, auto_evaluate=evaluate, dry_run=dry, debugging=debug
         )
 
     except (FileNotFoundError, NotADirectoryError) as e:

--- a/virtool_cli/update/cli.py
+++ b/virtool_cli/update/cli.py
@@ -28,11 +28,23 @@ def update():
     type=str,
     help="entry point for glob filter",
 )
-@click.option("--dry/--not-dry", default=False, help="Write to cache instead of reference")
-@click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
-@click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
+@click.option(
+    "--dry/--not-dry",
+    default=False,
+    help="Write to default cache directory instead of reference directory"
+)
+@click.option(
+    "--evaluate/--no-evaluate",
+    default=False,
+    help="Enable auto-evaluation"
+)
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable debugging logs"
+)
 def reference(src_path, filter, evaluate, dry, debug):
-    """Fetch new sequences and isolates for all OTU in a given reference directory."""
+    """Fetch new NCBI data for all OTU in a given reference directory."""
     try:
         run_update_all(src_path, filter, auto_evaluate=evaluate, dry_run=dry, debugging=debug)
     except (FileNotFoundError, NotADirectoryError) as e:
@@ -47,11 +59,23 @@ def reference(src_path, filter, evaluate, dry, debug):
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a single OTU directory",
 )
-@click.option("--dry/--not-dry", default=False, help="Write to cache instead of reference")
-@click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
-@click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
+@click.option(
+    "--dry/--not-dry",
+    default=False,
+    help="Write to default cache directory instead of reference directory"
+)
+@click.option(
+    "--evaluate/--no-evaluate",
+    default=False,
+    help="Enable auto-evaluation"
+)
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable debugging logs"
+)
 def otu(otu_path, evaluate, dry, debug):
-    """Fetch new sequences and isolates for a given OTU directory."""
+    """Fetch new NCBI data for a given OTU directory."""
 
     try:
         run_update_single(
@@ -77,10 +101,21 @@ def otu(otu_path, evaluate, dry, debug):
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a reference directory",
 )
-@click.option("--evaluate/--no-evaluate", default=False, help="Enable auto-filtering")
-@click.option("--debug/--no-debug", default=False, help="Enable debugging logs")
+@click.option(
+    "--evaluate/--no-evaluate",
+    default=False,
+    help="Enable auto-evaluation ()"
+)
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable debugging logs"
+)
 def uncache(cache_path, src_path, evaluate, debug):
-    """Fetch new sequences and isolates for all OTU in a given reference directory."""
+    """
+        Write cached sequence data under reference directory.
+        Read cached sequence data from a cache directory and write to a reference directory.
+    """
     try:
         run_update_uncache(cache_path, src_path, auto_evaluate=evaluate, debugging=debug)
     except (FileNotFoundError, NotADirectoryError) as e:

--- a/virtool_cli/update/uncache.py
+++ b/virtool_cli/update/uncache.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+import json
+import asyncio
+import structlog
+
+from virtool_cli.utils.logging import configure_logger
+from virtool_cli.utils.reference import is_v1
+from virtool_cli.update.writer import writer_loop
+
+DEFAULT_INTERVAL = 0.001
+
+base_logger = structlog.get_logger()
+
+
+def run(
+    cache_path: Path,
+    src_path: Path,
+    auto_evaluate: bool = False,
+    debugging: bool = False,
+):
+    """
+    CLI entry point for update.update_ref.run()
+
+    Requests updates for all OTU directories under a source reference
+
+    :param src_path: Path to a reference directory
+    :param auto_evaluate: Auto-evaluation flag, enables automatic filtering for fetched results
+    :param dry_run:
+    :param debugging: Enables verbose logs for debugging purposes
+    """
+    configure_logger(debugging)
+    logger = base_logger.bind(src=str(src_path))
+
+    if is_v1(src_path):
+        logger.error(
+            'reference folder "src" is a deprecated v1 reference.'
+            + 'Run "virtool ref migrate" before trying again.'
+        )
+        return
+
+    if auto_evaluate:
+        logger.warning(
+            "Auto-evaluation is in active development and may produce false negatives."
+        )
+
+    logger.info("Updating src directory accessions...")
+
+    asyncio.run(
+        update_reference_from_cache(
+            cache_path=cache_path, src_path=src_path, auto_evaluate=auto_evaluate
+        )
+    )
+
+
+async def update_reference_from_cache(
+    cache_path: Path, src_path: Path, auto_evaluate: bool = False
+):
+    """
+    """
+    # Holds raw NCBI GenBank data
+    queue = asyncio.Queue()
+
+    # Requests and retrieves new accessions from NCBI GenBank
+    # and pushes results to upstream queue
+    fetcher = asyncio.create_task(
+        loader_loop(cache_path=cache_path, queue=queue)
+    )
+
+    # Pulls formatted sequences from write queue, checks isolate metadata
+    # and writes json to the correct location in the src directory
+    asyncio.create_task(writer_loop(src_path, queue, cache_path, dry_run=False))
+
+    await asyncio.gather(*[fetcher], return_exceptions=True)
+
+    await queue.join()
+
+    return
+
+
+async def loader_loop(
+    cache_path: Path, queue: asyncio.Queue
+):
+    """
+    Loops through selected OTU listings from accession catalogue,
+    indexed by NCBI taxon ID, and:
+        1) requests NCBI Genbank for accession numbers not extant
+            in catalog,
+        2) loops through retrieved new accession numbers and
+            requests relevant record data from NCBI Genbank
+        3) Pushes new records and corresponding OTU information
+            to a queue for formatting
+
+    :param cache_path:
+    :param queue: Queue holding fetched NCBI GenBank data
+    """
+    logger = structlog.get_logger(__name__ + ".fetcher")
+    logger.debug("Starting loader...")
+
+    for path in cache_path.glob("*.json"):
+        otu_id = path.stem
+
+        logger = logger.bind(otu_id = otu_id)
+        logger.debug(f"Loading {otu_id}...")
+
+        with open(path, "r") as f:
+            record_data = json.load(f)
+
+        packet = {
+            "otu_id": otu_id,
+            "data": record_data,
+        }
+
+        await queue.put(packet)
+        logger.debug(
+            f"Pushed {len(record_data)} requests to queue",
+            n_requests=len(record_data)
+        )
+        await asyncio.sleep(DEFAULT_INTERVAL)

--- a/virtool_cli/update/uncache.py
+++ b/virtool_cli/update/uncache.py
@@ -68,7 +68,9 @@ async def update_reference_from_cache(
 
     # Pulls formatted sequences from write queue, checks isolate metadata
     # and writes json to the correct location in the src directory
-    asyncio.create_task(writer_loop(src_path, queue, cache_path, dry_run=False))
+    asyncio.create_task(
+        writer_loop(src_path, queue)
+    )
 
     await asyncio.gather(*[fetcher], return_exceptions=True)
 

--- a/virtool_cli/update/update.py
+++ b/virtool_cli/update/update.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 import asyncio
 import structlog
-from structlog import BoundLogger
+from structlog import BoundLogger, get_logger
 from urllib.error import HTTPError
 
+from virtool_cli.utils.format import process_default
 from virtool_cli.utils.ncbi import (
     request_linked_accessions,
     request_from_nucleotide,
@@ -64,3 +65,45 @@ async def request_new_records(
 
     return record_data
 
+
+async def process_records(
+    records: list,
+    metadata: dict,
+    no_fetch_set: set,
+    auto_evaluate: bool = True,
+    logger: BoundLogger = get_logger(),
+) -> list:
+    """
+    Takes sequence records and:
+        1) Evaluates whether those records should be added to the database,
+        2) Formats the records into a smaller dictionary
+        3) Returns new formatted dicts in a list
+
+    WARNING: Auto-evaluation is still under active development, especially multipartite filtering
+
+    :param records: SeqRecords retrieved from the NCBI Nucleotide database
+    :param metadata:
+    :param no_fetch_set:
+    :param auto_evaluate: Boolean flag for whether automatic evaluation functions
+        should be run
+    :param logger: Optional entry point for a shared BoundLogger
+    :return: A list of valid sequences formatted for the Virtool reference database
+    """
+    try:
+        otu_updates, auto_excluded = await process_default(
+            records, metadata, no_fetch_set, logger
+        )
+    except Exception as e:
+        logger.exception(e)
+        raise e
+
+    if auto_excluded:
+        logger.info(
+            "Consider adding these accessions to the exclusion list",
+            auto_excluded=auto_excluded,
+        )
+
+    if otu_updates:
+        return otu_updates
+
+    return []

--- a/virtool_cli/update/update.py
+++ b/virtool_cli/update/update.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import asyncio
-import json
 from structlog import BoundLogger, get_logger
 from urllib.error import HTTPError
 
@@ -107,12 +106,3 @@ async def process_records(
         return otu_updates
 
     return []
-
-
-async def write_summarized_update(
-    processed_updates: list, otu_id: str, cache_path: Path
-):
-    summary_path = cache_path / (otu_id + ".json")
-
-    with open(summary_path, "w") as f:
-        json.dump(processed_updates, f, indent=2, sort_keys=True)

--- a/virtool_cli/update/update.py
+++ b/virtool_cli/update/update.py
@@ -32,13 +32,14 @@ async def request_new_records(
     """
     try:
         upstream_accessions = await request_linked_accessions(taxon_id=taxid)
-        await asyncio.sleep(NCBI_REQUEST_INTERVAL)
     except HTTPError as e:
-        logger.error(e)
-        return []
+        logger.exception(e)
+        raise e
     except Exception as e:
         logger.exception(e)
         return []
+
+    await asyncio.sleep(NCBI_REQUEST_INTERVAL)
 
     if upstream_accessions:
         upstream_set = set(upstream_accessions)

--- a/virtool_cli/update/update.py
+++ b/virtool_cli/update/update.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import asyncio
-import structlog
+import json
 from structlog import BoundLogger, get_logger
 from urllib.error import HTTPError
 
@@ -11,8 +11,6 @@ from virtool_cli.utils.ncbi import (
     NCBI_REQUEST_INTERVAL,
 )
 from virtool_cli.utils.storage import get_otu_accessions, fetch_exclusions
-
-base_logger = structlog.get_logger()
 
 
 async def get_no_fetch_set(otu_path: Path):
@@ -25,7 +23,7 @@ async def get_no_fetch_set(otu_path: Path):
 
 
 async def request_new_records(
-    taxid: int, no_fetch_set: set, logger: BoundLogger = base_logger
+    taxid: int, no_fetch_set: set, logger: BoundLogger = get_logger()
 ) -> list:
     """
     :param taxid:
@@ -79,7 +77,8 @@ async def process_records(
         2) Formats the records into a smaller dictionary
         3) Returns new formatted dicts in a list
 
-    WARNING: Auto-evaluation is still under active development, especially multipartite filtering
+    WARNING: Auto-evaluation is still under active development,
+        especially multipartite filtering
 
     :param records: SeqRecords retrieved from the NCBI Nucleotide database
     :param metadata:
@@ -107,3 +106,12 @@ async def process_records(
         return otu_updates
 
     return []
+
+
+async def write_summarized_update(
+    processed_updates: list, otu_id: str, cache_path: Path
+):
+    summary_path = cache_path / (otu_id + ".json")
+
+    with open(summary_path, "w") as f:
+        json.dump(processed_updates, f, indent=2, sort_keys=True)

--- a/virtool_cli/update/update_otu.py
+++ b/virtool_cli/update/update_otu.py
@@ -6,7 +6,7 @@ from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import get_otu_paths, get_unique_ids
 from virtool_cli.utils.storage import read_otu, write_records
 from virtool_cli.update.update import get_no_fetch_set, request_new_records, process_records
-from virtool_cli.update.writer import write_summarized_update
+from virtool_cli.update.writer import cache_new_sequences
 
 base_logger = structlog.get_logger()
 
@@ -25,7 +25,9 @@ def run(
 
     :param otu_path: Path to an OTU directory
     :param auto_evaluate: Auto-evaluation flag, enables automatic filtering for fetched results
-    :param dry_run:
+    :param dry_run: Caching flag, writes all update data to a single file under
+        "{repo_path}/.cache/updates/{otu_id}.json",
+        instead of the reference directory
     :param debugging: Enables verbose logs for debugging purposes
     """
     configure_logger(debugging)
@@ -89,7 +91,7 @@ async def update_otu(
         update_cache_path = cache_path / "updates"
         update_cache_path.mkdir(exist_ok=True)
 
-        await write_summarized_update(otu_updates, otu_id, update_cache_path)
+        await cache_new_sequences(otu_updates, otu_id, update_cache_path)
 
         if not update_cache_path / f"{otu_id}.json".exists():
             logger.error("Write failed")

--- a/virtool_cli/update/update_otu.py
+++ b/virtool_cli/update/update_otu.py
@@ -71,6 +71,7 @@ async def update_otu(
         return
 
     if not record_data:
+        logger.debug("No records found.")
         return
 
     otu_updates = await process_records(
@@ -89,5 +90,8 @@ async def update_otu(
         update_cache_path.mkdir(exist_ok=True)
 
         await write_summarized_update(otu_updates, otu_id, update_cache_path)
+
+        if not update_cache_path / f"{otu_id}.json".exists():
+            logger.error("Write failed")
     else:
         await write_records(otu_path, otu_updates, unique_iso, unique_seq, logger=logger)

--- a/virtool_cli/update/update_otu.py
+++ b/virtool_cli/update/update_otu.py
@@ -6,7 +6,7 @@ from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import get_otu_paths, get_unique_ids
 from virtool_cli.utils.storage import read_otu, write_records
 from virtool_cli.update.update import get_no_fetch_set, request_new_records, process_records
-from virtool_cli.update.update import write_summarized_update
+from virtool_cli.update.writer import write_summarized_update
 
 base_logger = structlog.get_logger()
 

--- a/virtool_cli/update/update_ref.py
+++ b/virtool_cli/update/update_ref.py
@@ -9,9 +9,8 @@ from virtool_cli.utils.reference import (
     is_v1,
     get_unique_ids,
 )
-from virtool_cli.utils.format import process_records
 from virtool_cli.utils.storage import write_records, read_otu
-from virtool_cli.update.update import request_new_records, get_no_fetch_set
+from virtool_cli.update.update import request_new_records, get_no_fetch_set, process_records
 
 DEFAULT_INTERVAL = 0.001
 

--- a/virtool_cli/update/update_ref.py
+++ b/virtool_cli/update/update_ref.py
@@ -7,7 +7,7 @@ from virtool_cli.utils.logging import configure_logger
 from virtool_cli.utils.reference import is_v1
 from virtool_cli.utils.storage import read_otu
 from virtool_cli.update.update import request_new_records, get_no_fetch_set, process_records
-from virtool_cli.update.writer import writer_loop
+from virtool_cli.update.writer import writer_loop, cacher_loop
 
 DEFAULT_INTERVAL = 0.001
 
@@ -108,7 +108,14 @@ async def update_reference(
 
     # Pulls formatted sequences from write queue, checks isolate metadata
     # and writes json to the correct location in the src directory
-    asyncio.create_task(writer_loop(src_path, write_queue, update_cache_path, dry_run))
+    if dry_run:
+        asyncio.create_task(
+            cacher_loop(src_path, update_cache_path, write_queue)
+        )
+    else:
+        asyncio.create_task(
+            writer_loop(src_path, write_queue)
+        )
 
     await asyncio.gather(*[fetcher], return_exceptions=True)
 

--- a/virtool_cli/update/writer.py
+++ b/virtool_cli/update/writer.py
@@ -45,9 +45,11 @@ async def writer_loop(
 
         logger.debug("Writing packet...")
         await write_records(
-            otu_path,
-            sequence_data, unique_iso, unique_seq,
-            logger
+            otu_path=otu_path,
+            new_sequences=sequence_data,
+            unique_iso=unique_iso,
+            unique_seq=unique_seq,
+            logger=logger
         )
 
         await asyncio.sleep(DEFAULT_INTERVAL)

--- a/virtool_cli/update/writer.py
+++ b/virtool_cli/update/writer.py
@@ -16,8 +16,6 @@ DEFAULT_INTERVAL = 0.001
 async def writer_loop(
     src_path: Path,
     queue: asyncio.Queue,
-    cache_path: Path,
-    dry_run: bool = False
 ):
     """
     Awaits new sequence data for each OTU and writes new data into JSON files with unique Virtool IDs
@@ -32,40 +30,87 @@ async def writer_loop(
 
     while True:
         packet = await queue.get()
+        otu_id, sequence_data = await process_packet(packet)
 
-        otu_id = packet["otu_id"]
         logger = logger.bind(otu_id=otu_id)
 
         sequence_data = packet["data"]
 
-        logger.info(f"Packet {otu_id} taken from queue")
-
-        otu_path = search_otu_by_id(otu_id, src_path)
+        otu_path = await get_otu_path(otu_id, src_path, logger)
         if not otu_path:
-            logger.error("OTU path by id not found")
-
-            await asyncio.sleep(DEFAULT_INTERVAL)
             queue.task_done()
-
             continue
 
         logger = logger.bind(otu_path=str(otu_path))
 
         logger.debug("Writing packet...")
-
-        if dry_run:
-            await write_summarized_update(sequence_data, otu_id, cache_path)
-            cached_update_path = (cache_path / f"{otu_id}.json")
-            if cached_update_path.exists():
-                logger.debug(
-                    "Wrote summary to cache.",
-                    cached_update_path=str((cache_path / f"{otu_id}.json"))
-                )
-        else:
-            await write_records(otu_path, sequence_data, unique_iso, unique_seq, logger)
+        await write_records(
+            otu_path,
+            sequence_data, unique_iso, unique_seq,
+            logger
+        )
 
         await asyncio.sleep(DEFAULT_INTERVAL)
         queue.task_done()
+
+
+async def cacher_loop(
+    src_path: Path,
+    cache_path: Path,
+    queue: asyncio.Queue,
+):
+    """
+    Awaits new sequence data for each OTU and writes new data into JSON files with unique Virtool IDs
+
+    :param src_path: Path to a reference directory
+    :param queue: Queue holding formatted sequence and isolate data processed by this loop
+    """
+    logger = structlog.get_logger()
+    logger.debug("Starting cache writer...")
+
+    while True:
+        packet = await queue.get()
+        otu_id, sequence_data = await process_packet(packet)
+
+        logger = logger.bind(otu_id=otu_id)
+
+        logger.info(f"Packet {otu_id} taken from queue")
+
+        otu_path = await get_otu_path(otu_id, src_path, logger)
+        if not otu_path:
+            queue.task_done()
+            continue
+
+        logger = logger.bind(otu_path=str(otu_path))
+        logger.debug("Writing packet...")
+
+        await write_summarized_update(sequence_data, otu_id, cache_path)
+        cached_update_path = (cache_path / f"{otu_id}.json")
+        if cached_update_path.exists():
+            logger.debug(
+                "Wrote summary to cache.",
+                cached_update_path=str((cache_path / f"{otu_id}.json"))
+            )
+
+        await asyncio.sleep(DEFAULT_INTERVAL)
+        queue.task_done()
+
+
+async def get_otu_path(otu_id, src_path, logger):
+    otu_path = search_otu_by_id(otu_id, src_path)
+    if not otu_path:
+        logger.error("OTU path by id not found")
+
+        await asyncio.sleep(DEFAULT_INTERVAL)
+        return None
+
+    return otu_path
+
+async def process_packet(packet):
+    otu_id = packet["otu_id"]
+    sequence_data = packet["data"]
+
+    return otu_id, sequence_data
 
 
 async def write_summarized_update(

--- a/virtool_cli/update/writer.py
+++ b/virtool_cli/update/writer.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+import asyncio
+import structlog
+
+from virtool_cli.utils.reference import (
+    get_otu_paths,
+    search_otu_by_id,
+    get_unique_ids,
+)
+from virtool_cli.utils.storage import write_records
+
+DEFAULT_INTERVAL = 0.001
+
+
+async def writer_loop(
+    src_path: Path,
+    queue: asyncio.Queue,
+    cache_path: Path,
+    dry_run: bool = False
+):
+    """
+    Awaits new sequence data for each OTU and writes new data into JSON files with unique Virtool IDs
+
+    :param src_path: Path to a reference directory
+    :param queue: Queue holding formatted sequence and isolate data processed by this loop
+    """
+    logger = structlog.get_logger()
+    logger.debug("Starting writer...")
+
+    unique_iso, unique_seq = await get_unique_ids(get_otu_paths(src_path))
+
+    while True:
+        packet = await queue.get()
+
+        otu_id = packet["otu_id"]
+        logger = logger.bind(otu_id=otu_id)
+
+        sequence_data = packet["data"]
+
+        logger.info(f"Packet {otu_id} taken from queue")
+
+        otu_path = search_otu_by_id(otu_id, src_path)
+        if not otu_path:
+            logger.error("OTU path by id not found")
+
+            await asyncio.sleep(DEFAULT_INTERVAL)
+            queue.task_done()
+
+            continue
+
+        logger = logger.bind(otu_path=str(otu_path))
+
+        logger.debug("Writing packet...")
+
+        if dry_run:
+            await write_summarized_update(sequence_data, otu_id, cache_path)
+            cached_update_path = (cache_path / f"{otu_id}.json")
+            if cached_update_path.exists():
+                logger.debug(
+                    "Wrote summary to cache.",
+                    cached_update_path=str((cache_path / f"{otu_id}.json"))
+                )
+        else:
+            await write_records(otu_path, sequence_data, unique_iso, unique_seq, logger)
+
+        await asyncio.sleep(DEFAULT_INTERVAL)
+        queue.task_done()
+
+
+async def write_summarized_update(
+    processed_updates: list, otu_id: str, cache_path: Path
+):
+    summary_path = cache_path / (otu_id + ".json")
+
+    with open(summary_path, "w") as f:
+        json.dump(processed_updates, f, indent=2, sort_keys=True)

--- a/virtool_cli/utils/format.py
+++ b/virtool_cli/utils/format.py
@@ -74,7 +74,7 @@ def format_sequence(record: SeqRecord, qualifiers: dict) -> dict:
 
 def format_isolate(source_name: str, source_type: str, isolate_id: str) -> dict:
     """
-    Formats a
+    Formats raw isolate data for storage in a reference directory
 
     :param source_name: Assigned source name for an accession
     :param source_type: Assigned source type for an accession

--- a/virtool_cli/utils/format.py
+++ b/virtool_cli/utils/format.py
@@ -3,49 +3,6 @@ from structlog import BoundLogger, get_logger
 from typing import Tuple
 
 
-async def process_records(
-    records: list,
-    metadata: dict,
-    no_fetch_set: set,
-    auto_evaluate: bool = True,
-    logger: BoundLogger = get_logger(),
-) -> list:
-    """
-    Takes sequence records and:
-        1) Evaluates whether those records should be added to the database,
-        2) Formats the records into a smaller dictionary
-        3) Returns new formatted dicts in a list
-
-    WARNING: Auto-evaluation is still under active development, especially multipartite filtering
-
-    :param records: SeqRecords retrieved from the NCBI Nucleotide database
-    :param metadata:
-    :param no_fetch_set:
-    :param auto_evaluate: Boolean flag for whether automatic evaluation functions
-        should be run
-    :param logger: Optional entry point for a shared BoundLogger
-    :return: A list of valid sequences formatted for the Virtool reference database
-    """
-    try:
-        otu_updates, auto_excluded = await process_default(
-            records, metadata, no_fetch_set, logger
-        )
-    except Exception as e:
-        logger.exception(e)
-        raise e
-
-    if auto_excluded:
-        logger.info(
-            "Consider adding these accessions to the exclusion list",
-            auto_excluded=auto_excluded,
-        )
-
-    if otu_updates:
-        return otu_updates
-
-    return []
-
-
 async def process_default(
     records: list, metadata: dict, filter_set: set, logger: BoundLogger = get_logger()
 ) -> Tuple[list, list]:

--- a/virtool_cli/utils/format.py
+++ b/virtool_cli/utils/format.py
@@ -20,7 +20,7 @@ async def process_default(
     otu_updates = []
 
     for seq_data in records:
-        [accession, _] = seq_data.id.split(".")
+        accession = seq_data.id.split(".")[0]
         seq_qualifier_data = get_qualifiers(seq_data.features)
 
         if accession in filter_set:

--- a/virtool_cli/utils/ncbi.py
+++ b/virtool_cli/utils/ncbi.py
@@ -23,11 +23,13 @@ async def request_linked_accessions(taxon_id: int) -> list:
             dbfrom="taxonomy", db="nuccore",
             id=str(taxon_id), idtype="acc"
         )
+    except HTTPError as e:
+        raise e
+
+    try:
         entrez_acclist = Entrez.read(elink_results)
-    except HTTPError:
-        return []
-    except RuntimeError:
-        return []
+    except RuntimeError as e:
+        raise e
 
     if not entrez_acclist:
         return []

--- a/virtool_cli/utils/ncbi.py
+++ b/virtool_cli/utils/ncbi.py
@@ -2,6 +2,7 @@ import os
 import asyncio
 from Bio import Entrez, SeqIO
 from urllib.error import HTTPError
+from http.client import IncompleteRead
 
 Entrez.email = os.environ.get("NCBI_EMAIL")
 Entrez.api_key = os.environ.get("NCBI_API_KEY")
@@ -23,6 +24,8 @@ async def request_linked_accessions(taxon_id: int) -> list:
             dbfrom="taxonomy", db="nuccore",
             id=str(taxon_id), idtype="acc"
         )
+    except IncompleteRead:
+        raise HTTPError("IncompleteRead")
     except HTTPError as e:
         raise e
 
@@ -56,6 +59,8 @@ async def request_from_nucleotide(fetch_list: list) -> list:
         ncbi_records = SeqIO.to_dict(SeqIO.parse(handle, "gb"))
         handle.close()
 
+    except IncompleteRead:
+        raise HTTPError("IncompleteRead")
     except HTTPError as e:
         raise e
 
@@ -83,7 +88,9 @@ async def fetch_taxid(name: str) -> int:
         handle = Entrez.esearch(db="taxonomy", term=name)
         record = Entrez.read(handle)
         handle.close()
-    except Exception as e:
+    except IncompleteRead:
+        raise HTTPError("IncompleteRead")
+    except HTTPError as e:
         raise e
 
     try:
@@ -105,6 +112,8 @@ async def fetch_taxonomy_record(taxon_id) -> dict:
         handle = Entrez.efetch(db="taxonomy", id=taxon_id, rettype="docsum", retmode="xml")
         record = Entrez.read(handle)
         handle.close()
+    except IncompleteRead:
+        raise HTTPError("IncompleteRead")
     except HTTPError:
         raise HTTPError
 

--- a/virtool_cli/utils/reference.py
+++ b/virtool_cli/utils/reference.py
@@ -119,5 +119,3 @@ async def get_unique_otu_ids(src_path: Path) -> list:
         if otu_path.is_dir()
     ]
     return unique_otus
-
-


### PR DESCRIPTION
- feat: new `virtool ref update uncache` command: reads cached sequence data from a specified cache directory and writes it under the reference directory
- feat: new `--dry` flag for `virtool ref update otu` and `reference` commands: writes newly retrieved sequence data to single `{otu_id}.json` files under the default`.cache/updates` directory
- bugfix: accessions without version numbers no longer crash processes
- bugfix: handle a missing taxon ID in OTU metadata more gracefully
- bugfix: handle the IncompleteRead exception more gracefully 
- refactor: use `configure_logger()` where possible
- chore: minor fixes to CLI text