### PR TITLE
Bump minimum Python version to 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.ref_name }}
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Load cached Poetry installation
         id: cached-poetry
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pypi:
     runs-on: ubuntu-22.04
-    container: python:3.10
+    container: python:3.12
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ maintainers = [
 description = "CLI Tool for working with Virtool data"
 license = "MIT"
 classifiers = [
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.11"
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 aiofiles = "^23.1"
 aiohttp = "^3.8"
 arrow = "^1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ maintainers = [
 description = "CLI Tool for working with Virtool data"
 license = "MIT"
 classifiers = [
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.12"
 ]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 aiofiles = "^23.1"
 aiohttp = "^3.8"
 arrow = "^1.1"

--- a/virtool_cli/ncbi/model.py
+++ b/virtool_cli/ncbi/model.py
@@ -1,14 +1,14 @@
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
 
-class NCBIRank(str, Enum):
+class NCBIRank(StrEnum):
     SPECIES = "species"
     ISOLATE = "isolate"
 
 
-class NCBISourceType(str, Enum):
+class NCBISourceType(StrEnum):
     ISOLATE = "isolate"
     STRAIN = "strain"
     CLONE = "clone"


### PR DESCRIPTION
- Using `StrEnum` from 3.11 for convenience in model and future parser