### PR TITLE
Gate NCBI-dependent CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: poetry install
       - name: Run unit tests
         run: poetry run pytest -m "not ncbi" --disable-socket --allow-unix-socket
-      - name: Check if NCBI auth is present
+      - name: Check if NCBI auth is present, fail out if missing
         env:
           super_secret: ${{ secrets.NCBI_API_KEY }}
         if: ${{ env.super_secret == '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,18 @@ jobs:
         run: poetry install
       - name: Run unit tests
         run: poetry run pytest -m "not ncbi" --disable-socket --allow-unix-socket
+      - name: Check if NCBI auth is present
+        env:
+          super_secret: ${{ secrets.NCBI_API_KEY }}
+        if: ${{ env.super_secret == '' }}
+        run: |
+          echo "NCBI authentication not provided. Failing out."
+          exit 1
       - name: Run NCBI-dependent tests
-        if: github.event.pull_request.user == github.repository_owner
         run: poetry run pytest -m "ncbi"
-      - name: Mark unauthorized PR as unrunnable
-        if: github.event.pull_request.user != github.repository_owner
-        run: exit 1
+        env:
+          NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
+          NCBI_EMAIL: ${{ secrets.NCBI_EMAIL }}
   release:
     if: github.event_name == 'push'
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,8 @@ jobs:
         uses: snok/install-poetry@v1
       - name: Install packages
         run: poetry install
-      - name: Test
-        run: poetry run pytest
-        env:
-          NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
-          NCBI_EMAIL: ${{ secrets.NCBI_EMAIL }}
+      - name: Run unit tests
+        run: poetry run pytest -m "not ncbi" --disable-socket --allow-unix-socket
   release:
     if: github.event_name == 'push'
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
         run: poetry install
       - name: Run unit tests
         run: poetry run pytest -m "not ncbi" --disable-socket --allow-unix-socket
+      - name: Run NCBI-dependent tests
+        if: github.event.pull_request.user == github.repository_owner
+        run: poetry run pytest -m "ncbi"
+      - name: Mark unauthorized PR as unrunnable
+        if: github.event.pull_request.user != github.repository_owner
+        run: exit 1
   release:
     if: github.event_name == 'push'
     needs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -884,6 +884,20 @@ packaging = ">=17.1"
 pytest = ">=7.2"
 
 [[package]]
+name = "pytest-socket"
+version = "0.7.0"
+description = "Pytest Plugin to disable socket calls during tests"
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45"},
+    {file = "pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[[package]]
 name = "pytest-structlog"
 version = "0.6"
 description = "Structured logging assertions"
@@ -1120,4 +1134,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "54e9b77814eb040f08a2410152db0d1489bc98c0f4421a4a86afa6d2996a9651"
+content-hash = "046fc7c12d20e9211c053ee094126fcdd3e8173862b818938035ce0fb8cdeea7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ pytest-asyncio = "^0.23"
 pytest-cov = "^4.1"
 pytest-mock = "^3.12"
 pytest-structlog = "^0.6"
+pytest-socket = "^0.7"
 pytest-rerunfailures = "^14.0"
 syrupy = "^4.6.0"
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -22,6 +22,7 @@ def get_all_sequence_paths(otu_path: Path) -> set[Path]:
     }
 
 
+@pytest.mark.ncbi
 class TestAddAccession:
     @staticmethod
     def get_all_filenames_in_dir(path: Path) -> set[str]:
@@ -137,6 +138,7 @@ class TestAddAccession:
         assert get_all_sequence_paths(otu_path) == before
 
 
+@pytest.mark.ncbi
 class TestAddAccessions:
     @staticmethod
     def run_add_accessions(accessions: list[str], otu_dirname: str, path: Path):
@@ -205,6 +207,7 @@ class TestAddAccessions:
         assert post_sequence_paths == pre_sequence_paths
 
 
+@pytest.mark.ncbi
 class TestAddOTU:
     @staticmethod
     def run_add_otu(path: Path, taxid: int):


### PR DESCRIPTION
During CI, checks if an NCBI API key exists in the testing environment. If the API key is missing, fails `test` without running server tests.