### PR TITLE
More event sourcing

### DIFF
--- a/virtool_cli/console.py
+++ b/virtool_cli/console.py
@@ -1,3 +1,0 @@
-from rich.console import Console
-
-console = Console(highlight=False)

--- a/virtool_cli/ref/checking.py
+++ b/virtool_cli/ref/checking.py
@@ -1,0 +1,58 @@
+from pprint import pprint
+from typing import TYPE_CHECKING
+
+import orjson
+
+if TYPE_CHECKING:
+    from virtool_cli.ref.repo import EventSourcedRepo
+
+
+class Checker:
+    def __init__(self, repo: "EventSourcedRepo"):
+        self._repo = repo
+
+        self._cache_path = self._repo.path / ".cache" / "repo"
+        self._cache_path.mkdir(exist_ok=True)
+
+    def _cache_by_last_id(self, func, key: str):
+        last_id = self._repo.last_id
+
+        try:
+            with open(self._cache_path / f"{key}_{last_id}.json") as f:
+                return orjson.loads(f.read())
+        except FileNotFoundError:
+            data = func()
+
+            with open(self._cache_path / f"{key}_{last_id}.json", "wb") as f:
+                f.write(orjson.dumps(data))
+
+            return data
+
+    def check_legacy_id_exists(self, legacy_id: str | None):
+        pprint(list(self._repo.iter_otus()))
+
+        if legacy_id is None:
+            return
+
+        legacy_otu_ids = self._cache_by_last_id(
+            lambda: [
+                otu.legacy_id
+                for otu in self._repo.iter_otus()
+                if otu.legacy_id is not None
+            ],
+            "legacy_otu_ids",
+        )
+
+        print("legacy_otu_ids", legacy_otu_ids)
+
+        if legacy_id in legacy_otu_ids:
+            raise ValueError(f"An OTU with the legacy ID '{legacy_id}' already exists")
+
+    def check_otu_name_exists(self, name: str):
+        lowered_otu_names = self._cache_by_last_id(
+            lambda: [otu.name.lower() for otu in self._repo.iter_otus()],
+            "lowered_otu_names",
+        )
+
+        if name.lower() in set(lowered_otu_names):
+            raise ValueError(f"An OTU with the name '{name}' already exists")

--- a/virtool_cli/ref/events.py
+++ b/virtool_cli/ref/events.py
@@ -86,6 +86,7 @@ class CreateOTUData(EventData):
     id: UUID4
     acronym: str
     excluded_accessions: list[str]
+    legacy_id: str | None
     rep_isolate: UUID4 | None
     name: str
     otu_schema: list = Field(alias="schema")
@@ -103,6 +104,7 @@ class CreateIsolateData(EventData):
     """The data for the creation of a new isolate."""
 
     id: UUID4
+    legacy_id: str | None
     source_name: str
     source_type: str
 
@@ -120,6 +122,7 @@ class CreateSequenceData(EventData):
     id: UUID4
     accession: str
     definition: str
+    legacy_id: str | None
     segment: str
     sequence: str
 

--- a/virtool_cli/ref/events.py
+++ b/virtool_cli/ref/events.py
@@ -10,25 +10,25 @@ class EventQuery(BaseModel):
 
 
 class RepoQuery(EventQuery):
-    """Represents the query for targeting an event at a repository."""
+    """An event query that targets an event at a repository."""
 
     repository_id: UUID4
 
 
 class OTUQuery(EventQuery):
-    """Represents the query for targeting an event at an OTU."""
+    """An event query that targets an event at an OTU."""
 
     otu_id: UUID4
 
 
 class IsolateQuery(OTUQuery):
-    """Represents the query for targeting an event at an isolate."""
+    """An event query that targets an event at an isolate in a specific OTU."""
 
     isolate_id: UUID4
 
 
 class SequenceQuery(IsolateQuery):
-    """Represents the query for targeting an event at a sequence."""
+    """An event query that targets an event at a sequence in a specific isolate and OTU."""
 
     sequence_id: UUID4
 
@@ -41,10 +41,22 @@ class EventData(BaseModel):
 
 
 class Event(BaseModel):
+    """The base event."""
+
     id: int
+    """The unique identifier for the event.
+    
+    Event IDs are serially incremented integers.
+    """
+
     data: EventData
+    """The data associated with the event."""
+
     query: EventQuery
+    """The query targeting the event at a specific resource."""
+
     timestamp: datetime.datetime
+    """When the event occurred."""
 
     @computed_field
     @property
@@ -53,7 +65,7 @@ class Event(BaseModel):
 
 
 class CreateRepoData(EventData):
-    """Represents the data for the creation of a new repository."""
+    """The data for a repository creation event (`CreateRepo`)."""
 
     id: UUID4
     data_type: str
@@ -62,14 +74,14 @@ class CreateRepoData(EventData):
 
 
 class CreateRepo(Event):
-    """Represents the creation of a new repository."""
+    """A repo creation event."""
 
     data: CreateRepoData
     query: RepoQuery
 
 
 class CreateOTUData(EventData):
-    """Represents the data for the creation of a new OTU."""
+    """The data for the creation of a new OTU ('CreateOTU')."""
 
     id: UUID4
     acronym: str
@@ -81,14 +93,14 @@ class CreateOTUData(EventData):
 
 
 class CreateOTU(Event):
-    """Represents the creation of a new OTU."""
+    """An OTU creation event."""
 
     data: CreateOTUData
     query: OTUQuery
 
 
 class CreateIsolateData(EventData):
-    """Represents the data for the creation of a new isolate."""
+    """The data for the creation of a new isolate."""
 
     id: UUID4
     source_name: str
@@ -96,14 +108,14 @@ class CreateIsolateData(EventData):
 
 
 class CreateIsolate(Event):
-    """Represents the creation of a new isolate."""
+    """An isolate creation event."""
 
     data: CreateIsolateData
     query: IsolateQuery
 
 
 class CreateSequenceData(EventData):
-    """Represents the data for the creation of a new sequence."""
+    """The data for the creation of a new sequence."""
 
     id: UUID4
     accession: str
@@ -113,7 +125,7 @@ class CreateSequenceData(EventData):
 
 
 class CreateSequence(Event):
-    """Represents the creation of a new sequence."""
+    """A sequence creation event."""
 
     data: CreateSequenceData
     query: SequenceQuery

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -161,7 +161,14 @@ class EventSourcedRepo:
             otu = self.get_otu(otu_id)
             yield otu
 
-    def create_otu(self, acronym: str, name: str, schema: [], taxid: int):
+    def create_otu(
+        self,
+        acronym: str,
+        legacy_id: str | None,
+        name: str,
+        schema: [],
+        taxid: int,
+    ):
         """Create an OTU."""
         otu_id = uuid.uuid4()
 
@@ -171,6 +178,7 @@ class EventSourcedRepo:
                 id=otu_id,
                 acronym=acronym,
                 excluded_accessions=[],
+                legacy_id=legacy_id,
                 name=name,
                 schema=schema,
                 rep_isolate=None,
@@ -184,18 +192,26 @@ class EventSourcedRepo:
             acronym=acronym,
             excluded_accessions=[],
             isolates=[],
+            legacy_id=legacy_id,
             name=name,
             schema=schema,
             taxid=taxid,
         )
 
-    def create_isolate(self, otu_id: uuid.UUID, source_name: str, source_type: str):
+    def create_isolate(
+        self,
+        otu_id: uuid.UUID,
+        legacy_id: str | None,
+        source_name: str,
+        source_type: str,
+    ):
         isolate_id = uuid.uuid4()
 
         self._write_event(
             CreateIsolate,
             CreateIsolateData(
                 id=isolate_id,
+                legacy_id=legacy_id,
                 source_name=source_name,
                 source_type=source_type,
             ),
@@ -204,6 +220,7 @@ class EventSourcedRepo:
 
         return EventSourcedRepoIsolate(
             id=isolate_id,
+            legacy_id=legacy_id,
             sequences=[],
             source_name=source_name,
             source_type=source_type,
@@ -215,6 +232,7 @@ class EventSourcedRepo:
         isolate_id: uuid.UUID,
         accession: str,
         definition: str,
+        legacy_id: str | None,
         segment: str,
         sequence: str,
     ):
@@ -226,6 +244,7 @@ class EventSourcedRepo:
                 id=sequence_id,
                 accession=accession,
                 definition=definition,
+                legacy_id=legacy_id,
                 segment=segment,
                 sequence=sequence,
             ),
@@ -240,6 +259,7 @@ class EventSourcedRepo:
             id=sequence_id,
             accession=accession,
             definition=definition,
+            legacy_id=legacy_id,
             segment=segment,
             sequence=sequence,
         )
@@ -274,6 +294,7 @@ class EventSourcedRepo:
             acronym=event.data.acronym,
             excluded_accessions=event.data.excluded_accessions,
             isolates=[],
+            legacy_id=event.data.legacy_id,
             name=event.data.name,
             schema=event.data.otu_schema,
             taxid=event.data.taxid,
@@ -286,6 +307,7 @@ class EventSourcedRepo:
                 otu.add_isolate(
                     EventSourcedRepoIsolate(
                         id=event.data.id,
+                        legacy_id=event.data.legacy_id,
                         sequences=[],
                         source_name=event.data.source_name,
                         source_type=event.data.source_type,
@@ -300,6 +322,7 @@ class EventSourcedRepo:
                                 id=event.data.id,
                                 accession=event.data.accession,
                                 definition=event.data.definition,
+                                legacy_id=event.data.legacy_id,
                                 segment=event.data.segment,
                                 sequence=event.data.sequence,
                             ),

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -38,6 +38,12 @@ class EventSourcedRepoSequence:
     definition: str
     """The sequence definition."""
 
+    legacy_id: str | None
+    """A string based ID carried over from a legacy Virtool reference repository.
+
+    It the sequence was not migrated from a legacy repository, this will be `None`.    
+    """
+
     sequence: str
     """The sequence."""
 
@@ -49,6 +55,7 @@ class EventSourcedRepoSequence:
             "id": self.id,
             "accession": self.accession,
             "definition": self.definition,
+            "legacy_id": self.legacy_id,
             "sequence": self.sequence,
             "segment": self.segment,
         }
@@ -60,6 +67,12 @@ class EventSourcedRepoIsolate:
 
     id: UUID
     """The isolate id."""
+
+    legacy_id: str | None
+    """A string based ID carried over from a legacy Virtool reference repository.
+
+    It the isolate was not migrated from a legacy repository, this will be `None`.    
+    """
 
     source_name: str
     """The isolate's source name."""
@@ -76,6 +89,7 @@ class EventSourcedRepoIsolate:
     def dict(self):
         return {
             "id": self.id,
+            "legacy_id": self.legacy_id,
             "source_name": self.source_name,
             "source_type": self.source_type,
             "sequences": [sequence.dict() for sequence in self.sequences],
@@ -97,6 +111,12 @@ class EventSourcedRepoOTU:
     isolates: list[EventSourcedRepoIsolate]
     """A list of child isolates."""
 
+    legacy_id: str | None
+    """A string based ID carried over from a legacy Virtool reference repository.
+    
+    It the OTU was not migrated from a legacy repository, this will be `None`.    
+    """
+
     name: str
     """The OTU name (eg. Tobacco mosaic virus)."""
 
@@ -114,6 +134,7 @@ class EventSourcedRepoOTU:
             "acronym": self.acronym,
             "excluded_accessions": self.excluded_accessions,
             "isolates": [isolate.dict() for isolate in self.isolates],
+            "legacy_id": self.legacy_id,
             "name": self.name,
             "schema": self.schema,
             "taxid": self.taxid,

--- a/virtool_cli/utils/logging.py
+++ b/virtool_cli/utils/logging.py
@@ -13,39 +13,6 @@ logging.basicConfig(
     level=logging.DEBUG,
 )
 
-shared_processors = [
-    structlog.stdlib.filter_by_level,
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.stdlib.PositionalArgumentsFormatter(),
-    structlog.processors.StackInfoRenderer(),
-    structlog.processors.UnicodeDecoder(),
-    structlog.processors.CallsiteParameterAdder(
-        {
-            structlog.processors.CallsiteParameter.FILENAME,
-            structlog.processors.CallsiteParameter.FUNC_NAME,
-            structlog.processors.CallsiteParameter.LINENO,
-        },
-    ),
-]
-if sys.stderr.isatty() and not os.environ.get("NO_COLOR"):
-    processors = shared_processors + [
-        structlog.dev.ConsoleRenderer(),
-    ]
-else:
-    processors = shared_processors + [
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.format_exc_info,
-        structlog.processors.dict_tracebacks,
-        structlog.processors.JSONRenderer(),
-    ]
-
-structlog.configure(
-    processors=processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
 
 def configure_logger(debug: bool = False):
     """Wrapper for structlog configuration, determines logging level for the task.
@@ -53,6 +20,42 @@ def configure_logger(debug: bool = False):
 
     :param debug: Debugging flag. Defaults to False.
     """
+    processors = [
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.UnicodeDecoder(),
+    ]
+
+    if debug:
+        processors.append(
+            structlog.processors.CallsiteParameterAdder(
+                {
+                    structlog.processors.CallsiteParameter.FILENAME,
+                    structlog.processors.CallsiteParameter.FUNC_NAME,
+                    structlog.processors.CallsiteParameter.LINENO,
+                },
+            ),
+        )
+
+    if sys.stderr.isatty() and not os.environ.get("NO_COLOR"):
+        processors.append(structlog.dev.ConsoleRenderer())
+    else:
+        processors += [
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.format_exc_info,
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ]
+
+    structlog.configure(
+        processors=processors,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
     if debug:
         logger_level = logging.DEBUG
     else:


### PR DESCRIPTION
* Only log module details (filename, function, etc) in debug mode.
* Improve event class docstrings.
* Support `legacy_id` in `EventSourcedRepo`. This will allow old string IDs to be carried over during legacy migration.
* Add prototype of OTU creation by taxid. Uses new NCBI APIs. Still needs sequence aggregation and addition.
* Add framework for running checks across the repo before adding events (eg. duplicate OTU names).