### PR TITLE
fix: set entrez credentials on app load

### DIFF
--- a/virtool_cli/__init__.py
+++ b/virtool_cli/__init__.py
@@ -11,3 +11,10 @@ TODO: Allow exclusion checks at the Repo level.
 TODO: Don't use the term "blacklist". Use the word "exclusions" only.
 
 """
+
+import os
+
+from Bio import Entrez
+
+Entrez.email = os.environ.get("ENTREZ_EMAIL", None)
+Entrez.api_key = os.environ.get("ENTREZ_API_KEY", None)


### PR DESCRIPTION
Load the Entrez credentials from environment variables as soon as the CLI starts.