### PR TITLE
Partial CLI-57: EventIndexCache

### DIFF
--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -20,6 +20,31 @@ from virtool_cli.ref.utils import (
 )
 
 
+@pytest.fixture
+def initialized_repo(empty_repo: EventSourcedRepo):
+    otu = empty_repo.create_otu(
+        "TMV",
+        None,
+        "Tobacco mosaic virus",
+        Molecule(Strandedness.SINGLE, MolType.RNA, Topology.LINEAR),
+        [],
+        12242,
+    )
+
+    isolate_a = empty_repo.create_isolate(otu.id, None, "A", "isolate")
+    empty_repo.create_sequence(
+        otu.id,
+        isolate_a.id,
+        "TMVABC.1",
+        "TMV",
+        None,
+        "RNA",
+        "ACGT",
+    )
+
+    yield empty_repo
+
+
 def init_otu(empty_repo: EventSourcedRepo) -> EventSourcedRepoOTU:
     return empty_repo.create_otu(
         "TMV",
@@ -274,7 +299,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
         "ACGTGGAGAGACC",
     )
 
-    otu = empty_repo.get_otu(otu.id)
+    otu = empty_repo.get_otu(otu.id, ignore_cache=True)
 
     assert otu == EventSourcedRepoOTU(
         id=otu.id,
@@ -353,8 +378,56 @@ def test_exclude_accession(empty_repo: EventSourcedRepo):
             "type": "ExcludeAccession",
         }
 
-    assert empty_repo.get_otu(otu.id).excluded_accessions == ["TMVABC.1"]
+    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == [
+        "TMVABC.1"
+    ]
 
     empty_repo.exclude_accession(otu.id, "ABTV.1")
 
-    assert empty_repo.get_otu(otu.id).excluded_accessions == ["TMVABC.1", "ABTV.1"]
+    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == [
+        "TMVABC.1",
+        "ABTV.1",
+    ]
+
+
+class TestEventIndexCache:
+    def test_equivalence(self, initialized_repo: EventSourcedRepo):
+        assert initialized_repo.last_id == 4
+
+        otu = list(initialized_repo.iter_otus())[0]
+
+        otu_from_cache = initialized_repo.get_otu(otu.id, ignore_cache=False)
+        otu_from_scratch = initialized_repo.get_otu(otu.id, ignore_cache=True)
+        assert otu_from_cache == otu_from_scratch
+
+        isolate_b = initialized_repo.create_isolate(otu.id, None, "B", "isolate")
+        initialized_repo.create_sequence(
+            otu.id,
+            isolate_b.id,
+            "TMVABCB.1",
+            "TMV",
+            None,
+            "RNA",
+            "ACGTGGAGAGACC",
+        )
+
+        assert initialized_repo.last_id == 6
+
+        otu_from_cache = initialized_repo.get_otu(otu.id, ignore_cache=False)
+        otu_from_scratch = initialized_repo.get_otu(otu.id, ignore_cache=True)
+        assert otu_from_cache == otu_from_scratch
+
+    def test_retrieve_nonexistent_otu(self, initialized_repo: EventSourcedRepo):
+        assert (
+            initialized_repo.get_otu(
+                UUID("48b453fb-b60a-4f53-85f1-2941cd3ac5af"), ignore_cache=False
+            )
+            is None
+        )
+
+    def test_get_otu_without_cached_events(self, initialized_repo: EventSourcedRepo):
+        otu = list(initialized_repo.iter_otus())[0]
+
+        initialized_repo._event_index_cache.clear_otu_event_index_cache(otu.id)
+
+        assert initialized_repo.get_otu(otu.id, ignore_cache=False) is not None

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -428,6 +428,6 @@ class TestEventIndexCache:
     def test_get_otu_without_cached_events(self, initialized_repo: EventSourcedRepo):
         otu = list(initialized_repo.iter_otus())[0]
 
-        initialized_repo._event_index_cache.clear_otu_event_index_cache(otu.id)
+        initialized_repo._event_index_cache.clear_cached_otu_events(otu.id)
 
         assert initialized_repo.get_otu(otu.id, ignore_cache=False) is not None

--- a/virtool_cli/ref/event_index_cache.py
+++ b/virtool_cli/ref/event_index_cache.py
@@ -53,8 +53,6 @@ class EventIndexCache:
         ]
 
     def cache_index(self, event_index: dict[UUID, list[int]], last_id: int):
-        """Takes an event index and caches each individual OTU's events
-        under a separate file."""
         for otu_id in event_index:
             self.cache_otu_events(otu_id, event_index[otu_id], last_id=last_id)
 
@@ -81,7 +79,7 @@ class EventIndexCache:
 
     def load_otu_events(self, otu_id: UUID) -> OTUEventCache | None:
         """
-        Takes a requested OTU Id and returns an OTUEventRecord(at_event, events)
+        Takes a requested OTU Id and returns an OTUEventCache(otu_id, at_event, events)
         if possible, else None if the event record does not exist.
 
         If the cached data is not compatible with the repo's event store,

--- a/virtool_cli/ref/event_index_cache.py
+++ b/virtool_cli/ref/event_index_cache.py
@@ -52,7 +52,7 @@ class EventIndexCache:
             if subpath.suffix == ".json"
         ]
 
-    def populate(self, event_index: dict[UUID, list[int]], last_id: int):
+    def cache_index(self, event_index: dict[UUID, list[int]], last_id: int):
         """Takes an event index and caches each individual OTU's events
         under a separate file."""
         for otu_id in event_index:

--- a/virtool_cli/ref/event_index_cache.py
+++ b/virtool_cli/ref/event_index_cache.py
@@ -1,0 +1,106 @@
+import shutil
+import dataclasses
+from pathlib import Path
+from uuid import UUID
+from typing import Annotated
+
+import orjson
+from pydantic import Field, ValidationError
+from pydantic.dataclasses import dataclass
+
+from structlog import get_logger
+
+logger = get_logger("repo.cache.event_index")
+
+
+@dataclass
+class OTUEventIndex:
+    at_event: Annotated[int, Field(ge=1)]
+    """The latest event ID when this cache index was last updated"""
+
+    events: list[int]
+    """A list of event IDs"""
+
+
+class EventIndexCacheError(Exception):
+    """Event index cache is corrupted."""
+
+
+class EventIndexCache:
+    """Maintains a cache of for each OTU UUID in the repo"""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+        self.path.mkdir(exist_ok=True)
+
+    def list_otu_ids(self) -> list[UUID]:
+        """Returns a list of OTU Ids with extant data in the cache."""
+        return [
+            UUID(subpath.stem)
+            for subpath in self.path.iterdir()
+            if subpath.suffix == ".json"
+        ]
+
+    def populate(self, event_index: dict[UUID, list[int]], last_id: int):
+        """Takes an event index and caches each individual OTU's events
+        under a separate file."""
+        for otu_id in event_index:
+            self.cache_otu_events(otu_id, event_index[otu_id], last_id=last_id)
+
+    def clear(self):
+        """Clear and reset cache."""
+        shutil.rmtree(self.path)
+        self.path.mkdir()
+
+    def cache_otu_events(self, otu_id: UUID, event_list: list[int], last_id: int = 1):
+        """
+        :param otu_id: A Virtool OTU Id
+        :param event_list: A list of event IDs
+        :param last_id: The last added Id in the event store at point of caching
+        """
+        index_data = OTUEventIndex(at_event=last_id, events=event_list)
+
+        try:
+            with open(self.path / f"{otu_id}.json", "wb") as f:
+                f.write(orjson.dumps(dataclasses.asdict(index_data)))
+        finally:
+            logger.debug(
+                "OTU event index updated", otu_id=str(otu_id), events=event_list
+            )
+
+    def load_otu_event_index(self, otu_id: UUID) -> OTUEventIndex | None:
+        """
+        Takes a requested OTU Id and the last recorded Event Id in the event store
+        and returns an OTUEventIndex(at_event, events) if possible.
+
+        Returns None if the cached event list is nonexistent.
+
+        If the cached data is not compatible with the repo's event store,
+        raise an EventIndexCacheError.
+
+        :param otu_id: A Virtool OTU Id
+        :param last_id: The last added Id in the event store at point of caching
+        :return: OTUEventIndex(at_event, events) if a valid event list
+            can be found in the cache, else None
+        """
+        cached_path = self.path / f"{otu_id}.json"
+
+        if not cached_path.exists():
+            return None
+
+        with open(cached_path, "rb") as f:
+            cached_data = orjson.loads(f.read())
+
+        try:
+            otu_index_cache = OTUEventIndex(**cached_data)
+        except ValidationError:
+            raise EventIndexCacheError(
+                "Bad Index: Events could not be retrieved from cache"
+            )
+
+        return otu_index_cache
+
+    def clear_otu_event_index_cache(self, otu_id: UUID):
+        """Delete a given OTU's cached data from the cache."""
+        (self.path / f"{otu_id}.json").unlink(missing_ok=True)

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -139,8 +139,8 @@ class EventSourcedRepo:
         """The path to the repo src directory."""
         return self.path / "src"
 
-    def _iter_events(self):
-        for path in sorted(self.src_path.iterdir()):
+    def _iter_events(self, reverse: bool = False):
+        for path in sorted(self.src_path.iterdir(), reverse=reverse):
             yield _read_event_at_path(path)
 
     def _iter_events_from_index(self, start: int = 1) -> Generator[Event, None, None]:
@@ -191,7 +191,7 @@ class EventSourcedRepo:
         return event
 
     def _get_event_index(self) -> dict[uuid.UUID, list[int]]:
-        """Get the current event index, binned and indexed by OTU Id"""
+        """Get the current event index from the event store, binned and indexed by OTU Id."""
         otu_event_index = defaultdict(list)
 
         for event in self._iter_events():

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -339,11 +339,15 @@ class EventSourcedRepo:
             OTUQuery(otu_id=otu_id),
         )
 
-    def get_otu(self, otu_id: uuid.UUID) -> EventSourcedRepoOTU:
+    def get_otu(
+        self, otu_id: uuid.UUID, ignore_cache: bool = False
+    ) -> EventSourcedRepoOTU:
         """Get an OTU by its ID."""
         pprint(list(self._iter_events()))
 
-        event_ids = self._get_otu_event_list(otu_id)
+        event_ids = self._get_otu_event_list(otu_id, ignore_cache)
+        if not event_ids:
+            return None
 
         first_event_id = event_ids[0]
 

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -50,11 +50,7 @@ from virtool_cli.ref.resources import (
     EventSourcedRepoSequence,
     RepoMeta,
 )
-from virtool_cli.ref.event_index_cache import (
-    EventIndexCache,
-    OTUEventIndex,
-    EventIndexCacheError,
-)
+from virtool_cli.ref.event_index_cache import EventIndexCache, EventIndexCacheError
 
 from virtool_cli.ref.utils import DataType, IsolateName, Molecule, pad_zeroes
 

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -50,6 +50,12 @@ from virtool_cli.ref.resources import (
     EventSourcedRepoSequence,
     RepoMeta,
 )
+from virtool_cli.ref.event_index_cache import (
+    EventIndexCache,
+    OTUEventIndex,
+    EventIndexCacheError,
+)
+
 from virtool_cli.ref.utils import DataType, IsolateName, Molecule, pad_zeroes
 
 logger = get_logger("repo")
@@ -71,6 +77,10 @@ class EventSourcedRepo:
             self.last_id = event.id
 
         self.checker = Checker(self)
+
+        self.cache_path = self.path / ".cache"
+
+        self._event_index_cache = EventIndexCache(self.cache_path / "event_index")
 
         logger.info("Finished loading repository", event_count=self.last_id)
 
@@ -134,6 +144,22 @@ class EventSourcedRepo:
         for path in sorted(self.src_path.iterdir()):
             yield _read_event_at_path(path)
 
+    def _iter_events_from_index(self, start: int = 1) -> Generator[Event, None, None]:
+        """Iterates through events in the src directory using the index id.
+
+        :param start: The event ID to be read first.
+            Setting start > 1 will begin the iterator
+            from the middle of the event store.
+        """
+        if start < 1:
+            raise IndexError("Start index cannot be <1")
+
+        if start > self.last_id:
+            raise IndexError(f"Start index cannot be >{self.last_id}")
+
+        for iterator in range(start, self.last_id):
+            yield self._read_event(iterator)
+
     def _read_event(self, event_id: int) -> Event:
         return _read_event_at_path(self.src_path / f"{pad_zeroes(event_id)}.json")
 
@@ -164,6 +190,28 @@ class EventSourcedRepo:
         self.last_id = event_id
 
         return event
+
+    def _get_event_index(self) -> dict[uuid.UUID, list[int]]:
+        """Get the current event index, binned and indexed by OTU ID"""
+        otu_event_index = defaultdict(list)
+
+        for event in self._iter_events():
+            if type(event) in (CreateOTU, CreateIsolate, CreateSequence):
+                otu_event_index[event.query.otu_id].append(event.id)
+
+        return otu_event_index
+
+    def _get_event_index_after_start(
+        self, start: int = 1
+    ) -> dict[uuid.UUID, list[int]]:
+        """Get the current event index, binned and indexed by OTU ID"""
+        otu_event_index = defaultdict(list)
+
+        for event in self._iter_events_from_index(start):
+            if type(event) in (CreateOTU, CreateIsolate, CreateSequence):
+                otu_event_index[event.query.otu_id].append(event.id)
+
+        return otu_event_index
 
     def iter_otus(self) -> Generator[EventSourcedRepoOTU, None, None]:
         """Iterate over the OTUs in the repository."""
@@ -295,15 +343,7 @@ class EventSourcedRepo:
         """Get an OTU by its ID."""
         pprint(list(self._iter_events()))
 
-        event_ids = [
-            event.id
-            for event in self._iter_events()
-            if (
-                type(event)
-                in (CreateOTU, CreateIsolate, CreateSequence, ExcludeAccession)
-                and event.query.otu_id == otu_id
-            )
-        ]
+        event_ids = self._get_otu_event_list(otu_id)
 
         first_event_id = event_ids[0]
 
@@ -358,6 +398,98 @@ class EventSourcedRepo:
                         )
 
         return otu
+
+    def _get_otu_event_list(
+        self, otu_id: uuid.UUID, ignore_cache: bool = False
+    ) -> list[int]:
+        """
+        Returns an up-to-date list of events associated with this OTU Id.
+
+        If ignore_cache, loads the OTU's event index cache and makes sure
+        the results are up to date before returning the list.
+
+        If cache load fails or ignore_cache is False, generates a new event list.
+        """
+        otu_logger = logger.bind(otu_id=str(otu_id), ignore_cache=ignore_cache)
+
+        if not ignore_cache:
+            try:
+                otu_event_list = self._load_otu_event_list_from_cache_and_update(otu_id)
+
+                if otu_event_list:
+                    return otu_event_list
+
+                otu_logger.error("Event index cache was empty.")
+
+            except EventIndexCacheError as e:
+                logger.error(e)
+                logger.warning("Deleting bad index...")
+
+                self._event_index_cache.clear_otu_event_index_cache(otu_id)
+
+        otu_logger.debug("Searching event store for matching events...")
+        return [
+            event.id
+            for event in self._iter_events()
+            if (
+                type(event)
+                in (CreateOTU, CreateIsolate, CreateSequence, ExcludeAccession)
+                and event.query.otu_id == otu_id
+            )
+        ]
+
+    def _load_otu_event_list_from_cache_and_update(
+        self, otu_id: uuid.UUID
+    ) -> list[int]:
+        """Gets OTU events from the event index cache,
+        updates the list it is not up to date and returns the list.
+        """
+        otu_logger = logger.bind(otu_id=str(otu_id))
+
+        cached_otu_index = None
+        try:
+            cached_otu_index = self._event_index_cache.load_otu_event_index(otu_id)
+
+        except EventIndexCacheError as e:
+            logger.error(e)
+
+            logger.warning("Deleting bad index...")
+
+            self._event_index_cache.clear_otu_event_index_cache(otu_id)
+
+        if cached_otu_index is not None:
+            if cached_otu_index.at_event == self.last_id:
+                return cached_otu_index.events
+
+            elif cached_otu_index.at_event < self.last_id:
+                otu_logger.warning("Cached event list is out of date")
+
+                otu_event_set = set(cached_otu_index.events)
+
+                for event in self._iter_events_from_index(
+                    start=cached_otu_index.at_event
+                ):
+                    if type(event) in (
+                        CreateOTU,
+                        CreateIsolate,
+                        CreateSequence,
+                        ExcludeAccession,
+                    ):
+                        otu_event_set.add(event.id)
+
+                    otu_logger.debug(
+                        "Added new events to event list.",
+                        updated_events=otu_event_set,
+                    )
+
+                return list(otu_event_set)
+
+            else:
+                raise EventIndexCacheError(
+                    "Bad Index: Cached event index is greater than current repo's last ID"
+                )
+
+        return []
 
 
 def _write_event(


### PR DESCRIPTION
- Add `ref.event_index_cache.EventIndexCache`
- Add `EventSourcedRepo._event_index_cache` and integrate cache and load into default `.get_otu()` operation
- Add `EventSourcedRepo._get_event_index()` and `._get_event_index_after_start()` - - Add `EventSourcedRepo._load_otu_event_index()`