### PR TITLE
Exlude accessions with an event

### DIFF
--- a/virtool_cli/ref/events.py
+++ b/virtool_cli/ref/events.py
@@ -89,12 +89,11 @@ class CreateOTUData(EventData):
 
     id: UUID4
     acronym: str
-    excluded_accessions: list[str]
     legacy_id: str | None
-    rep_isolate: UUID4 | None
-    name: str
     molecule: Molecule | None
+    name: str
     otu_schema: list = Field(alias="schema")
+    rep_isolate: UUID4 | None
     taxid: int
 
 
@@ -136,3 +135,20 @@ class CreateSequence(Event):
 
     data: CreateSequenceData
     query: SequenceQuery
+
+
+class ExcludeAccessionData(EventData):
+    """The data for the exclusion of an accession."""
+
+    accession: str
+
+
+class ExcludeAccession(Event):
+    """An accession exclusion event.
+
+    This event is emitted when a Genbank accession is not going to be allowed in the
+    reference.
+    """
+
+    data: ExcludeAccessionData
+    query: OTUQuery

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -80,9 +80,6 @@ class EventSourcedRepoIsolate:
     sequences: list[EventSourcedRepoSequence]
     """A list of child sequences."""
 
-    def add_sequence(self, sequence: EventSourcedRepoSequence):
-        self.sequences.append(sequence)
-
     def dict(self):
         return {
             "id": self.id,


### PR DESCRIPTION
* Add `ExcludeAccession` event.
* Use `OTUQuery` for the event, which scopes it to a particular OTU.
* Remove `excluded_accessions` from the `CreateOTU` event.
* Add test.