### PR TITLE
Fix for event indexing bug & minor utility functions/properties

### DIFF
--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -432,6 +432,26 @@ def test_get_blocked_accessions(initialized_repo: EventSourcedRepo):
     assert otu.blocked_accession_set == {"TMVABC", "TMVABCB", "GROK", "TOK"}
 
 
+def test_get_isolate(initialized_repo: EventSourcedRepo):
+    otu = list(initialized_repo.iter_otus())[0]
+
+    isolate_ids = {isolate.id for isolate in otu.isolates}
+
+    for isolate_id in isolate_ids:
+        assert otu.get_isolate(isolate_id) in otu.isolates
+
+
+def test_get_isolate_id_by_name(initialized_repo: EventSourcedRepo):
+    otu = list(initialized_repo.iter_otus())[0]
+
+    isolate_ids = {isolate.id for isolate in otu.isolates}
+
+    assert (
+        otu.get_isolate_id_by_name(IsolateName(type="isolate", value="A"))
+        in isolate_ids
+    )
+
+
 class TestEventIndexCache:
     def test_equivalence(self, initialized_repo: EventSourcedRepo):
         assert initialized_repo.last_id == 4

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -390,6 +390,47 @@ def test_exclude_accession(empty_repo: EventSourcedRepo):
     }
 
 
+def test_get_accessions(initialized_repo: EventSourcedRepo):
+    otu = list(initialized_repo.iter_otus())[0]
+
+    assert otu.accession_set == {"TMVABC"}
+
+    isolate_b = initialized_repo.create_isolate(otu.id, None, "B", "isolate")
+    initialized_repo.create_sequence(
+        otu.id,
+        isolate_b.id,
+        "TMVABCB",
+        "TMV",
+        None,
+        "RNA",
+        "ACGTGGAGAGACC",
+    )
+
+    otu = list(initialized_repo.iter_otus())[0]
+
+    assert otu.accession_set == {"TMVABC", "TMVABCB"}
+
+
+def test_get_blocked_accessions(initialized_repo: EventSourcedRepo):
+    otu_id = initialized_repo.index_otus()[12242]
+    isolate_b = initialized_repo.create_isolate(otu_id, None, "B", "isolate")
+    initialized_repo.create_sequence(
+        otu_id,
+        isolate_b.id,
+        "TMVABCB",
+        "TMV",
+        None,
+        "RNA",
+        "ACGTGGAGAGACC",
+    )
+
+    initialized_repo.exclude_accession(otu_id, "GROK")
+    initialized_repo.exclude_accession(otu_id, "TOK")
+
+    otu = initialized_repo.get_otu(otu_id)
+
+    assert otu.blocked_accession_set == {"TMVABC", "TMVABCB", "GROK", "TOK"}
+
 
 class TestEventIndexCache:
     def test_equivalence(self, initialized_repo: EventSourcedRepo):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -35,7 +35,7 @@ def initialized_repo(empty_repo: EventSourcedRepo):
     empty_repo.create_sequence(
         otu.id,
         isolate_a.id,
-        "TMVABC.1",
+        "TMVABC",
         "TMV",
         None,
         "RNA",
@@ -85,7 +85,7 @@ class TestCreateOTU:
         assert otu == EventSourcedRepoOTU(
             id=otu.id,
             acronym="TMV",
-            excluded_accessions=[],
+            excluded_accessions=set(),
             isolates=[],
             legacy_id="abcd1234",
             name="Tobacco mosaic virus",
@@ -222,7 +222,7 @@ def test_create_sequence(empty_repo: EventSourcedRepo):
     sequence = empty_repo.create_sequence(
         otu.id,
         isolate.id,
-        "TMVABC.1",
+        "TMVABC",
         "TMV",
         None,
         "RNA",
@@ -231,7 +231,7 @@ def test_create_sequence(empty_repo: EventSourcedRepo):
 
     assert sequence == EventSourcedRepoSequence(
         id=sequence.id,
-        accession="TMVABC.1",
+        accession="TMVABC",
         definition="TMV",
         legacy_id=None,
         segment="RNA",
@@ -246,7 +246,7 @@ def test_create_sequence(empty_repo: EventSourcedRepo):
     assert event == {
         "data": {
             "id": str(sequence.id),
-            "accession": "TMVABC.1",
+            "accession": "TMVABC",
             "definition": "TMV",
             "legacy_id": None,
             "segment": "RNA",
@@ -281,7 +281,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
     empty_repo.create_sequence(
         otu.id,
         isolate_a.id,
-        "TMVABC.1",
+        "TMVABC",
         "TMV",
         None,
         "RNA",
@@ -292,7 +292,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
     empty_repo.create_sequence(
         otu.id,
         isolate_b.id,
-        "TMVABCB.1",
+        "TMVABCB",
         "TMV",
         None,
         "RNA",
@@ -304,7 +304,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
     assert otu == EventSourcedRepoOTU(
         id=otu.id,
         acronym="TMV",
-        excluded_accessions=[],
+        excluded_accessions=set(),
         legacy_id=None,
         isolates=[
             EventSourcedRepoIsolate(
@@ -314,7 +314,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
                 sequences=[
                     EventSourcedRepoSequence(
                         id=otu.isolates[0].sequences[0].id,
-                        accession="TMVABC.1",
+                        accession="TMVABC",
                         definition="TMV",
                         legacy_id=None,
                         segment="RNA",
@@ -329,7 +329,7 @@ def test_get_otu(empty_repo: EventSourcedRepo):
                 sequences=[
                     EventSourcedRepoSequence(
                         id=otu.isolates[1].sequences[0].id,
-                        accession="TMVABCB.1",
+                        accession="TMVABCB",
                         definition="TMV",
                         legacy_id=None,
                         segment="RNA",
@@ -360,7 +360,7 @@ def test_exclude_accession(empty_repo: EventSourcedRepo):
         12242,
     )
 
-    empty_repo.exclude_accession(otu.id, "TMVABC.1")
+    empty_repo.exclude_accession(otu.id, "TMVABC")
 
     with open(empty_repo.path.joinpath("src", "00000003.json")) as f:
         event = orjson.loads(f.read())
@@ -369,7 +369,7 @@ def test_exclude_accession(empty_repo: EventSourcedRepo):
 
         assert event == {
             "data": {
-                "accession": "TMVABC.1",
+                "accession": "TMVABC",
             },
             "id": 3,
             "query": {
@@ -378,16 +378,17 @@ def test_exclude_accession(empty_repo: EventSourcedRepo):
             "type": "ExcludeAccession",
         }
 
-    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == [
-        "TMVABC.1"
-    ]
+    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == {
+        "TMVABC"
+    }
 
-    empty_repo.exclude_accession(otu.id, "ABTV.1")
+    empty_repo.exclude_accession(otu.id, "ABTV")
 
-    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == [
-        "TMVABC.1",
-        "ABTV.1",
-    ]
+    assert empty_repo.get_otu(otu.id, ignore_cache=True).excluded_accessions == {
+        "TMVABC",
+        "ABTV",
+    }
+
 
 
 class TestEventIndexCache:
@@ -404,7 +405,7 @@ class TestEventIndexCache:
         initialized_repo.create_sequence(
             otu.id,
             isolate_b.id,
-            "TMVABCB.1",
+            "TMVABCB",
             "TMV",
             None,
             "RNA",

--- a/virtool_cli/ncbi/model.py
+++ b/virtool_cli/ncbi/model.py
@@ -120,7 +120,7 @@ class NCBIGenbank(BaseModel):
         ),
     ]
     source: Annotated[NCBISource, Field(validation_alias="GBSeq_feature-table")]
-    comment: Annotated[str, Field("", validation_alias="GBSeq_comment")]
+    comment: Annotated[str, Field(validation_alias="GBSeq_comment")] = ""
 
     @computed_field()
     def refseq(self) -> bool:
@@ -164,11 +164,11 @@ class NCBILineage(BaseModel):
 
 
 class NCBITaxonomyOtherNames(BaseModel):
-    acronym: Annotated[list[str], Field([], validation_alias="Acronym")]
-    genbank_acronym: Annotated[list[str], Field([], validation_alias="GenbankAcronym")]
-    equivalent_name: Annotated[list[str], Field([], validation_alias="EquivalentName")]
-    synonym: Annotated[list[str], Field([], validation_alias="Synonym")]
-    includes: Annotated[list[str], Field([], validation_alias="Includes")]
+    acronym: Annotated[list[str], Field(validation_alias="Acronym")] = []
+    genbank_acronym: Annotated[list[str], Field(validation_alias="GenbankAcronym")] = []
+    equivalent_name: Annotated[list[str], Field(validation_alias="EquivalentName")] = []
+    synonym: Annotated[list[str], Field(validation_alias="Synonym")] = []
+    includes: Annotated[list[str], Field(validation_alias="Includes")] = []
 
 
 class NCBITaxonomy(BaseModel):
@@ -178,8 +178,8 @@ class NCBITaxonomy(BaseModel):
     name: Annotated[str, Field(validation_alias="ScientificName")]
     other_names: Annotated[
         NCBITaxonomyOtherNames,
-        Field(NCBITaxonomyOtherNames(), validation_alias="OtherNames"),
-    ]
+        Field(validation_alias="OtherNames"),
+    ] = NCBITaxonomyOtherNames()
     lineage: Annotated[list[NCBILineage], Field(validation_alias="LineageEx")]
     rank: Annotated[NCBIRank, Field(validation_alias=AliasChoices("rank", "Rank"))]
 

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -221,7 +221,17 @@ class EventSourcedRepo:
             otu = self.get_otu(otu_id)
             yield otu
 
-    def index_otus(self):
+    def index_otus(self, ignore_cache: bool = False):
+        if not ignore_cache:
+            otu_ids = self._event_index_cache.list_otu_ids()
+
+            otu_index = {}
+            for otu_id in otu_ids:
+                otu = self.get_otu(otu_id, ignore_cache)
+                if otu:
+                    otu_index[otu.taxid] = otu_id
+            return otu_index
+
         return {otu.taxid: otu.id for otu in self.iter_otus()}
 
     def create_otu(

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -156,11 +156,8 @@ class EventSourcedRepo:
         if start > self.last_id:
             raise IndexError(f"Start index cannot be >{self.last_id}")
 
-        for iterator in range(start, self.last_id + 1):
-            yield self._read_event(iterator)
-
-    def _print_events(self):
-        pprint(list(self._iter_events()))
+        for event_index in range(start, self.last_id + 1):
+            yield self._read_event(event_index)
 
     def _read_event(self, event_id: int) -> Event:
         return _read_event_at_path(self.src_path / f"{pad_zeroes(event_id)}.json")

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -384,7 +384,7 @@ class EventSourcedRepo:
         otu = EventSourcedRepoOTU(
             id=event.data.id,
             acronym=event.data.acronym,
-            excluded_accessions=[],
+            excluded_accessions=set(),
             isolates=[],
             legacy_id=event.data.legacy_id,
             molecule=event.data.molecule,
@@ -407,7 +407,7 @@ class EventSourcedRepo:
                 )
 
             elif isinstance(event, ExcludeAccession):
-                otu.excluded_accessions.append(event.data.accession)
+                otu.excluded_accessions.add(event.data.accession)
 
             elif isinstance(event, CreateSequence):
                 for isolate in otu.isolates:

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -221,6 +221,9 @@ class EventSourcedRepo:
             otu = self.get_otu(otu_id)
             yield otu
 
+    def index_otus(self):
+        return {otu.taxid: otu.id for otu in self.iter_otus()}
+
     def create_otu(
         self,
         acronym: str,

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -156,7 +156,7 @@ class EventSourcedRepo:
         if start > self.last_id:
             raise IndexError(f"Start index cannot be >{self.last_id}")
 
-        for iterator in range(start, self.last_id):
+        for iterator in range(start, self.last_id + 1):
             yield self._read_event(iterator)
 
     def _read_event(self, event_id: int) -> Event:

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -24,11 +24,6 @@ class RepoMeta(BaseModel):
     organism: str
     """The repository organism."""
 
-    @field_validator("data_type", mode="before")
-    @classmethod
-    def datatype_conversion(cls, raw: str) -> DataType:
-        return DataType(raw)
-
 
 @dataclass
 class EventSourcedRepoSequence:
@@ -86,7 +81,7 @@ class EventSourcedRepoIsolate:
     """A list of child sequences."""
 
     @property
-    def accessions(self) -> list:
+    def accession_list(self) -> list:
         """Return a list of accessions contained in this isolate"""
         return [sequence.accession for sequence in self.sequences]
 
@@ -136,17 +131,19 @@ class EventSourcedRepoOTU:
     """The schema of the OTU"""
 
     @property
-    def accessions(self) -> list:
+    def accession_list(self) -> list:
         """Return a list of accessions contained in this isolate"""
         accessions = []
         for isolate in self.isolates:
-            accessions = accessions + isolate.accessions
+            accessions += isolate.accession_list
 
         return accessions
 
     @property
-    def blocked_accessions(self) -> list:
-        return self.accessions + self.excluded_accessions
+    def blocked_accession_list(self) -> list:
+        """Returns a list of accessions to be blocked from fetches,
+        i.e. accessions that have already been added and excluded accessions."""
+        return self.accession_list + self.excluded_accessions
 
     def get_isolate(self, isolate_id: UUID) -> EventSourcedRepoIsolate | None:
         """Return the isolate instance associated with a given UUID if it exists,

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -1,12 +1,12 @@
 import datetime
 from dataclasses import dataclass
+from pydantic import BaseModel, field_validator
 from uuid import UUID
 
 from virtool_cli.ref.utils import DataType, IsolateName, Molecule
 
 
-@dataclass
-class RepoMeta:
+class RepoMeta(BaseModel):
     """Represents the metadata for a Virtool reference repository."""
 
     id: UUID
@@ -23,6 +23,11 @@ class RepoMeta:
 
     organism: str
     """The repository organism."""
+
+    @field_validator("data_type", mode="before")
+    @classmethod
+    def datatype_conversion(cls, raw: str) -> DataType:
+        return DataType(raw)
 
 
 @dataclass
@@ -81,7 +86,7 @@ class EventSourcedRepoIsolate:
     """A list of child sequences."""
 
     @property
-    def accessions(self):
+    def accessions(self) -> list:
         return [sequence.accession for sequence in self.sequences]
 
     def add_sequence(self, sequence: EventSourcedRepoSequence):
@@ -130,7 +135,7 @@ class EventSourcedRepoOTU:
     """The schema of the OTU"""
 
     @property
-    def accessions(self):
+    def accessions(self) -> list:
         accessions = []
         for isolate in self.isolates:
             accessions = [*accessions, *isolate.accessions]

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -81,9 +81,9 @@ class EventSourcedRepoIsolate:
     """A list of child sequences."""
 
     @property
-    def accession_list(self) -> list:
-        """Return a list of accessions contained in this isolate"""
-        return [sequence.accession for sequence in self.sequences]
+    def accession_set(self) -> set:
+        """Return a set of accessions contained in this isolate"""
+        return {sequence.accession for sequence in self.sequences}
 
     def dict(self):
         return {
@@ -104,7 +104,7 @@ class EventSourcedRepoOTU:
     acronym: str
     """The OTU acronym (eg. TMV for Tobacco mosaic virus)."""
 
-    excluded_accessions: list[str]
+    excluded_accessions: set[str]
 
     isolates: list[EventSourcedRepoIsolate]
     """A list of child isolates."""
@@ -128,19 +128,19 @@ class EventSourcedRepoOTU:
     """The schema of the OTU"""
 
     @property
-    def accession_list(self) -> list:
-        """Return a list of accessions contained in this isolate"""
-        accessions = []
+    def accession_set(self) -> set:
+        """Return a set of accessions contained in this isolate"""
+        accessions = set()
         for isolate in self.isolates:
-            accessions += isolate.accession_list
+            accessions.update(isolate.accession_set)
 
         return accessions
 
     @property
-    def blocked_accession_list(self) -> list:
-        """Returns a list of accessions to be blocked from fetches,
+    def blocked_accession_set(self) -> set:
+        """Returns a set of accessions to be blocked from fetches,
         i.e. accessions that have already been added and excluded accessions."""
-        return self.accession_list + self.excluded_accessions
+        return self.accession_set.union(self.excluded_accessions)
 
     def get_isolate(self, isolate_id: UUID) -> EventSourcedRepoIsolate | None:
         """Return the isolate instance associated with a given UUID if it exists,

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -152,7 +152,7 @@ class EventSourcedRepoOTU:
 
         return None
 
-    def get_isolate_id(self, type: str, name: str) -> UUID | None:
+    def get_isolate_id_by_name(self, type: str, name: str) -> UUID | None:
         """Return an UUID if the name is extant in this OTU."""
         for isolate in self.isolates:
             if isolate.name.type == type and isolate.name.value == name:

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -85,9 +85,6 @@ class EventSourcedRepoIsolate:
         """Return a list of accessions contained in this isolate"""
         return [sequence.accession for sequence in self.sequences]
 
-    def add_sequence(self, sequence: EventSourcedRepoSequence):
-        self.sequences.append(sequence)
-
     def dict(self):
         return {
             "id": self.id,
@@ -162,9 +159,6 @@ class EventSourcedRepoOTU:
                 return isolate.id
 
         return None
-
-    def add_isolate(self, isolate: EventSourcedRepoIsolate):
-        self.isolates.append(isolate)
 
     def dict(self):
         return {

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -80,6 +80,13 @@ class EventSourcedRepoIsolate:
     sequences: list[EventSourcedRepoSequence]
     """A list of child sequences."""
 
+    @property
+    def accessions(self):
+        return [sequence.accession for sequence in self.sequences]
+
+    def add_sequence(self, sequence: EventSourcedRepoSequence):
+        self.sequences.append(sequence)
+
     def dict(self):
         return {
             "id": self.id,
@@ -113,13 +120,40 @@ class EventSourcedRepoOTU:
     name: str
     """The OTU name (eg. Tobacco mosaic virus)."""
 
-    molecule: Molecule
-    """The molecule of this OTU"""
-
     taxid: int
     """The OTU taxonomy ID."""
 
-    schema: list
+    molecule: Molecule | None = None
+    """The molecule of this OTU"""
+
+    schema: list | None = None
+    """The schema of the OTU"""
+
+    @property
+    def accessions(self):
+        accessions = []
+        for isolate in self.isolates:
+            accessions = [*accessions, *isolate.accessions]
+
+        return accessions
+
+    @property
+    def nofetch(self):
+        return [*self.accessions, *self.excluded_accessions]
+
+    def get_isolate(self, isolate_id) -> EventSourcedRepoIsolate | None:
+        for isolate in self.isolates:
+            if isolate.id == isolate_id:
+                return isolate
+
+        return None
+
+    def get_isolate_id(self, type: str, name: str) -> UUID | None:
+        for isolate in self.isolates:
+            if isolate.name.type == type and isolate.name.value == name:
+                return isolate.id
+
+        return None
 
     def add_isolate(self, isolate: EventSourcedRepoIsolate):
         self.isolates.append(isolate)

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -87,6 +87,7 @@ class EventSourcedRepoIsolate:
 
     @property
     def accessions(self) -> list:
+        """Return a list of accessions contained in this isolate"""
         return [sequence.accession for sequence in self.sequences]
 
     def add_sequence(self, sequence: EventSourcedRepoSequence):
@@ -136,17 +137,21 @@ class EventSourcedRepoOTU:
 
     @property
     def accessions(self) -> list:
+        """Return a list of accessions contained in this isolate"""
         accessions = []
         for isolate in self.isolates:
-            accessions = [*accessions, *isolate.accessions]
+            accessions = accessions + isolate.accessions
 
         return accessions
 
     @property
-    def nofetch(self):
-        return [*self.accessions, *self.excluded_accessions]
+    def blocked_accessions(self) -> list:
+        return self.accessions + self.excluded_accessions
 
-    def get_isolate(self, isolate_id) -> EventSourcedRepoIsolate | None:
+    def get_isolate(self, isolate_id: UUID) -> EventSourcedRepoIsolate | None:
+        """Return the isolate instance associated with a given UUID if it exists,
+        else None.
+        """
         for isolate in self.isolates:
             if isolate.id == isolate_id:
                 return isolate
@@ -154,6 +159,7 @@ class EventSourcedRepoOTU:
         return None
 
     def get_isolate_id(self, type: str, name: str) -> UUID | None:
+        """Return an UUID if the name is extant in this OTU."""
         for isolate in self.isolates:
             if isolate.name.type == type and isolate.name.value == name:
                 return isolate.id

--- a/virtool_cli/ref/resources.py
+++ b/virtool_cli/ref/resources.py
@@ -152,10 +152,10 @@ class EventSourcedRepoOTU:
 
         return None
 
-    def get_isolate_id_by_name(self, type: str, name: str) -> UUID | None:
+    def get_isolate_id_by_name(self, name: IsolateName) -> UUID | None:
         """Return an UUID if the name is extant in this OTU."""
         for isolate in self.isolates:
-            if isolate.name.type == type and isolate.name.value == name:
+            if isolate.name == name:
                 return isolate.id
 
         return None

--- a/virtool_cli/ref/utils.py
+++ b/virtool_cli/ref/utils.py
@@ -6,7 +6,7 @@ import orjson
 from pydantic import BaseModel, field_validator
 
 
-class DataType:
+class DataType(StrEnum):
     BARCODE = "barcode"
     GENOME = "genome"
 


### PR DESCRIPTION
- Fix: Off-by-one error in `Repo._iter_events_from_index()`
- Add: `Repo.index_otus()` returns a `taxid: otu_id` list
- Add: `.accessions` properties for `OTU` and `Isolate`
- Add: `OTU.nofetch` property
- Add: `OTU.get_isolate()` and `OTU.get_isolate_id()`
- Refactor: `NCBIGenbank` now has default values in correct position
- Refactor: Miscellaneous debugging logs
