### PR TITLE
Refactor lower-level `EventSourcedRepo` functionality into `EventIndex` and `EventStore`

### DIFF
--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -533,6 +533,6 @@ class TestEventIndexCache:
     def test_get_otu_without_cached_events(self, initialized_repo: EventSourcedRepo):
         otu = list(initialized_repo.iter_otus())[0]
 
-        initialized_repo._index._cache.clear_cached_otu_events(otu.id)
+        initialized_repo._event_index._cache.clear_cached_otu_events(otu.id)
 
         assert initialized_repo.get_otu(otu.id, ignore_cache=False) is not None

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -533,6 +533,6 @@ class TestEventIndexCache:
     def test_get_otu_without_cached_events(self, initialized_repo: EventSourcedRepo):
         otu = list(initialized_repo.iter_otus())[0]
 
-        initialized_repo._event_index_cache.clear_cached_otu_events(otu.id)
+        initialized_repo._index._cache.clear_cached_otu_events(otu.id)
 
         assert initialized_repo.get_otu(otu.id, ignore_cache=False) is not None

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -542,6 +542,8 @@ class EventSourcedRepo:
 
 
 class EventStore:
+    """Interface for the event store"""
+
     def __init__(self, path: Path):
         self.path = path
 

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -359,29 +359,6 @@ class EventSourcedRepo:
 
         return otu
 
-    def _get_otu_metadata(self, event_ids: list[int]) -> dict | None:
-        """Retrieves OTU metadata from a list of event IDs"""
-        if not event_ids:
-            return None
-        event_ids.sort()
-        first_event_id = event_ids[0]
-
-        event = self._src.read_event(first_event_id)
-
-        if not isinstance(event, CreateOTU):
-            raise ValueError(
-                f"The first event ({first_event_id}) for an OTU is not a CreateOTU "
-                "event",
-            )
-
-        return {
-            "id": event.data.id,
-            "acronym": event.data.acronym,
-            "legacy_id": event.data.legacy_id,
-            "name": event.data.name,
-            "taxid": event.data.taxid,
-        }
-
 
 class EventIndex:
     def __init__(self, event_store: "EventStore", cache_path: Path):

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -424,9 +424,8 @@ class EventIndex:
                 otu_index[otu_metadata["taxid"]] = otu_id
         return otu_index
 
-    def list_otu_ids(self, ignore_cache: bool = False):
-        if not ignore_cache:
-            return self._cache.list_otu_ids()
+    def list_otu_ids(self, ignore_cache: bool = False) -> list[uuid.UUID]:
+        return list(self.get(ignore_cache).keys())
 
     def get(self, ignore_cache: bool = False) -> dict[uuid.UUID, list[int]]:
         if not ignore_cache:
@@ -470,7 +469,7 @@ class EventIndex:
 
         if not ignore_cache:
             try:
-                otu_event_list = self.load_otu_events_and_update(otu_id)
+                otu_event_list = self._load_otu_events_and_update(otu_id)
 
                 if otu_event_list:
                     otu_logger.debug(
@@ -506,7 +505,7 @@ class EventIndex:
 
         return event_ids
 
-    def load_otu_events_and_update(self, otu_id: uuid.UUID) -> list[int]:
+    def _load_otu_events_and_update(self, otu_id: uuid.UUID) -> list[int]:
         """Gets OTU events from the event index cache,
         updates the list it is not up to date and returns the list.
         """

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -542,7 +542,7 @@ class EventSourcedRepo:
 
 
 class EventStore:
-    def __init__(self, path):
+    def __init__(self, path: Path):
         self.path = path
 
         self.last_id = 0

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -70,7 +70,7 @@ class EventSourcedRepo:
 
         self._src = EventStore(self.path / "src")
 
-        self._index = EventIndex(
+        self._event_index = EventIndex(
             self._src, cache_path=(self.cache_path / "event_index")
         )
 
@@ -142,12 +142,12 @@ class EventSourcedRepo:
         self, ignore_cache: bool = False
     ) -> Generator[EventSourcedRepoOTU, None, None]:
         """Iterate over the OTUs in the repository."""
-        for otu_id in self._index.get(ignore_cache):
+        for otu_id in self._event_index.get(ignore_cache):
             otu = self.get_otu(otu_id, ignore_cache)
             yield otu
 
     def index_otus(self, ignore_cache: bool = False):
-        return self._index.index_otu_metadata(ignore_cache)
+        return self._event_index.index_otu_metadata(ignore_cache)
 
     def create_otu(
         self,
@@ -287,7 +287,7 @@ class EventSourcedRepo:
     ) -> EventSourcedRepoOTU | None:
         """Return an OTU corresponding with a given OTU Id if it exists, else None."""
         logger.debug("Getting OTU from events...", otu_id=str(otu_id))
-        event_ids = self._index.get_otu_events(otu_id, ignore_cache)
+        event_ids = self._event_index.get_otu_events(otu_id, ignore_cache)
 
         if event_ids:
             return self._rehydrate_otu(event_ids)

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -136,7 +136,7 @@ class EventSourcedRepo:
     @property
     def src_path(self) -> Path:
         """The path to the repo src directory."""
-        return self.path / "src"
+        return self._src.path
 
     def _get_event_index(self) -> dict[uuid.UUID, list[int]]:
         """Get the current event index from the event store,

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -556,16 +556,20 @@ class EventStore:
 
     @property
     def event_ids(self) -> list:
-        return sorted(
-            [
-                int(event_path.stem)
-                for event_path in self.path.iterdir()
-                if event_path.suffix == ".json"
-            ]
-        )
+        event_ids = []
+        for event_path in self.path.iterdir():
+            try:
+                event_ids.append(int(event_path.stem))
+            except ValueError:
+                continue
+        event_ids.sort()
+
+        return event_ids
 
     def iter_events(self, reverse: bool = False):
-        for path in sorted(self.path.iterdir(), reverse=reverse):
+        for path in sorted(self.path.glob("*.json"), reverse=reverse):
+            if path.stem == "meta":
+                continue
             yield _read_event_at_path(path)
 
     def iter_events_from_index(self, start: int = 1) -> Generator[Event, None, None]:


### PR DESCRIPTION
- Refactor `src` write and load into `EventStore`, accessed through `EventSourcedRepo._src`
- Refactor OTU ID keyed event index and event index cache into `EventIndex`, accessed through `EventSourcedRepo._event_index`
- `EventIndexCache` now accessed solely through `EventSourcedRepo._cache`