### PR TITLE
Snapshotter cleanup 1

### DIFF
--- a/tests/snapshot/test_index.py
+++ b/tests/snapshot/test_index.py
@@ -81,7 +81,7 @@ class TestSnapshotIndexCaching:
 
         assert rehydrated_otu
 
-        snapshot_otu = snapshotter.load_otu_by_taxid(taxid)
+        snapshot_otu = snapshotter.load_by_taxid(taxid)
 
         assert snapshot_otu
 

--- a/tests/snapshot/test_index.py
+++ b/tests/snapshot/test_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+from virtool_cli.ref.repo import EventSourcedRepo
 from virtool_cli.ref.snapshot.index import Snapshotter
 
 
@@ -19,27 +20,36 @@ class TestSnapshotIndex:
         for otu_id in true_otu_ids:
             assert otu_id in snapshotter.id_to_taxid
 
-    def test_taxids(self, scratch_repo, snapshotter):
-        true_otu_taxids = [
-            otu.taxid for otu in scratch_repo.get_all_otus(ignore_cache=True)
-        ]
+    def test_load_by_id(self, snapshotter: Snapshotter, scratch_repo: EventSourcedRepo):
+        """Test that we can load an OTU by its ID."""
+        otu_ids = [otu.id for otu in scratch_repo.get_all_otus(ignore_cache=True)]
 
-        assert snapshotter.taxids
+        for otu_id in otu_ids:
+            assert snapshotter.load_by_id(otu_id).id == otu_id
 
-        assert len(true_otu_taxids) == len(snapshotter.taxids)
+    def test_load_by_taxid(
+        self,
+        scratch_repo: EventSourcedRepo,
+        snapshotter: Snapshotter,
+    ):
+        """Test that we can load an OTU by its taxid."""
+        taxids = [otu.taxid for otu in scratch_repo.get_all_otus(ignore_cache=True)]
 
-        for taxid in true_otu_taxids:
-            assert taxid in snapshotter.index_by_taxid
+        for taxid in taxids:
+            assert snapshotter.load_by_taxid(taxid).taxid == taxid
 
-    def test_names(self, scratch_repo, snapshotter):
+    def test_load_by_name(
+        self,
+        scratch_repo: EventSourcedRepo,
+        snapshotter: Snapshotter,
+    ):
+        """Test that we can load an OTU by its name."""
         true_otu_names = [
             otu.name for otu in scratch_repo.get_all_otus(ignore_cache=True)
         ]
 
-        assert len(true_otu_names) == len(snapshotter.index_by_name)
-
         for name in true_otu_names:
-            assert name in snapshotter.index_by_name
+            assert snapshotter.load_by_name(name).name == name
 
     def test_accessions(self, scratch_repo, snapshotter):
         true_accessions = set()

--- a/tests/snapshot/test_index.py
+++ b/tests/snapshot/test_index.py
@@ -1,11 +1,11 @@
 import pytest
 
-from virtool_cli.ref.snapshot.index import SnapshotIndex
+from virtool_cli.ref.snapshot.index import Snapshotter
 
 
 @pytest.fixture()
 def snapshotter(scratch_repo):
-    return SnapshotIndex(scratch_repo.path / ".cache/snapshot")
+    return Snapshotter(scratch_repo.path / ".cache/snapshot")
 
 
 class TestSnapshotIndex:
@@ -69,7 +69,11 @@ class TestSnapshotIndexCaching:
         ],
     )
     def test_load_otu_by_taxid(
-        self, taxid: int, accessions: list[str], scratch_repo, snapshotter
+        self,
+        taxid: int,
+        accessions: list[str],
+        scratch_repo,
+        snapshotter,
     ):
         scratch_repo.snapshot()
 

--- a/virtool_cli/ref/otu.py
+++ b/virtool_cli/ref/otu.py
@@ -14,19 +14,22 @@ base_logger = structlog.get_logger()
 
 
 def create_otu(
-    repo: EventSourcedRepo, taxid: int, ignore_cache: bool = False
+    repo: EventSourcedRepo,
+    taxid: int,
+    ignore_cache: bool = False,
 ) -> EventSourcedRepoOTU:
     """Initialize a new OTU from a Taxonomy ID."""
     logger = base_logger.bind(taxid=taxid)
 
-    if taxid in repo.taxids:
+    if repo.get_otu_by_taxid(taxid):
         raise ValueError(
-            f"Taxonomy ID {taxid} has already been added to this reference."
+            f"Taxonomy ID {taxid} has already been added to this reference.",
         )
 
     ncbi = NCBIClient.from_repo(repo.path, ignore_cache)
 
     taxonomy = ncbi.fetch_taxonomy_record(taxid)
+
     if taxonomy is None:
         logger.fatal(f"Taxonomy ID {taxid} not found")
         sys.exit(1)
@@ -49,10 +52,13 @@ def create_otu(
 
 
 def update_otu(
-    repo: EventSourcedRepo, otu: EventSourcedRepoOTU, ignore_cache: bool = False
+    repo: EventSourcedRepo,
+    otu: EventSourcedRepoOTU,
+    ignore_cache: bool = False,
 ):
     """Fetch a full list of Nucleotide accessions associated with the OTU
-    and pass the list to the add method."""
+    and pass the list to the add method.
+    """
     ncbi = NCBIClient.from_repo(repo.path, ignore_cache)
 
     linked_accessions = ncbi.link_accessions_from_taxid(otu.taxid)
@@ -79,10 +85,8 @@ def group_genbank_records_by_isolate(
             for source_type in IsolateNameType:
                 if source_type in record.source.model_fields_set:
                     isolate_name = IsolateName(
-                        **{
-                            "type": IsolateNameType(source_type),
-                            "value": record.source.model_dump()[source_type],
-                        },
+                        type=IsolateNameType(source_type),
+                        value=record.source.model_dump()[source_type],
                     )
 
                     isolates[isolate_name][record.accession] = record
@@ -97,10 +101,8 @@ def group_genbank_records_by_isolate(
             )
 
             isolate_name = IsolateName(
-                **{
-                    "type": IsolateNameType(IsolateNameType.REFSEQ),
-                    "value": record.accession,
-                },
+                type=IsolateNameType(IsolateNameType.REFSEQ),
+                value=record.accession,
             )
 
             isolates[isolate_name][record.accession] = record
@@ -119,7 +121,8 @@ def add_sequences(
     ignore_cache: bool = False,
 ):
     """Take a list of accessions, filter for eligible accessions and
-    add new sequences to the OTU"""
+    add new sequences to the OTU
+    """
     client = NCBIClient.from_repo(repo.path, ignore_cache)
 
     otu_logger = base_logger.bind(taxid=otu.taxid, otu_id=str(otu.id), name=otu.name)
@@ -147,7 +150,7 @@ def add_sequences(
         isolate_id = otu.get_isolate_id_by_name(isolate_key)
         if isolate_id is None:
             otu_logger.debug(
-                f"Creating isolate for {isolate_key.type}, {isolate_key.value}"
+                f"Creating isolate for {isolate_key.type}, {isolate_key.value}",
             )
             isolate = repo.create_isolate(
                 otu_id=otu.id,
@@ -181,7 +184,7 @@ def add_sequences(
         )
 
     else:
-        otu_logger.info(f"No new sequences added to OTU")
+        otu_logger.info("No new sequences added to OTU")
 
 
 def get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:
@@ -189,17 +192,13 @@ def get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:
     for record in records:
         if record.refseq:
             return Molecule(
-                **{
-                    "strandedness": record.strandedness.value,
-                    "type": record.moltype.value,
-                    "topology": record.topology.value,
-                }
+                strandedness=record.strandedness.value,
+                type=record.moltype.value,
+                topology=record.topology.value,
             )
 
     return Molecule(
-        **{
-            "strandedness": records[0].strandedness.value,
-            "type": records[0].moltype.value,
-            "topology": records[0].topology.value,
-        }
+        strandedness=records[0].strandedness.value,
+        type=records[0].moltype.value,
+        topology=records[0].topology.value,
     )

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -212,9 +212,9 @@ class EventSourcedRepo:
         taxid: int,
     ):
         """Create an OTU."""
-        if self.get_otu_by_taxid(taxid):
+        if otu := self.get_otu_by_taxid(taxid):
             raise ValueError(
-                f"OTU already exists as {self._snapshotter.index_by_taxid[taxid]}",
+                f"OTU already exists as {otu}",
             )
 
         if name in self._snapshotter.index_by_name:

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -212,12 +212,14 @@ class EventSourcedRepo:
         taxid: int,
     ):
         """Create an OTU."""
-        if taxid in self._snapshotter.taxids:
+        if self.get_otu_by_taxid(taxid):
             raise ValueError(
                 f"OTU already exists as {self._snapshotter.index_by_taxid[taxid]}",
             )
+
         if name in self._snapshotter.index_by_name:
             raise ValueError(f"An OTU with the name '{name}' already exists")
+
         if legacy_id in self._snapshotter.index_by_legacy_id:
             raise ValueError(f"An OTU with the legacy ID '{legacy_id}' already exists")
 
@@ -380,13 +382,13 @@ class EventSourcedRepo:
         """Return an OTU corresponding to a UUID if found in snapshot, else None"""
         logger.debug("Loading OTU from snapshot...", otu_id=str(otu_id))
 
-        return self._snapshotter.load_otu(otu_id)
+        return self._snapshotter.load_by_id(otu_id)
 
     def read_otu_by_taxid(self, taxid: int) -> EventSourcedRepoOTU | None:
         """Return an OTU corresponding to a Taxonomy ID if found in snapshot, else None"""
         logger.debug("Loading OTU from snapshot...", taxid=taxid)
 
-        return self._snapshotter.load_otu_by_taxid(taxid)
+        return self._snapshotter.load_by_taxid(taxid)
 
     def get_otu(
         self,

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -149,16 +149,6 @@ class EventSourcedRepo:
         """The path to the repo src directory."""
         return self._event_store.path
 
-    @property
-    def taxids(self) -> set:
-        """Extant Taxonomy ids in the read model"""
-        return self._snapshotter.taxids
-
-    @property
-    def accessions(self) -> set:
-        """Extant accessions in the read model"""
-        return self._snapshotter.accessions
-
     def _get_event_index(self) -> dict[uuid.UUID, list[int]]:
         """Get the current event index from the event store,
         binned and indexed by OTU Id.

--- a/virtool_cli/ref/repo.py
+++ b/virtool_cli/ref/repo.py
@@ -78,7 +78,7 @@ class EventSourcedRepo:
         self._event_index_cache = EventIndexCache(self.cache_path / "event_index")
         """The event index cache of the event sourced repository."""
 
-        self._snapshotter = (
+        self._snapshotter: Snapshotter = (
             Snapshotter(path=self._snapshot_path)
             if self._snapshot_path.exists()
             else Snapshotter.new(path=self._snapshot_path, metadata=self.meta)
@@ -403,6 +403,12 @@ class EventSourcedRepo:
             return self._rehydrate_otu(event_ids)
 
         return None
+
+    def get_otu_by_name(
+        self,
+        name: str,
+    ):
+        return self._snapshotter.load_by_name(name)
 
     def get_otu_by_taxid(
         self,

--- a/virtool_cli/ref/snapshot/index.py
+++ b/virtool_cli/ref/snapshot/index.py
@@ -1,4 +1,3 @@
-import shutil
 from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
@@ -123,13 +122,6 @@ class Snapshotter:
         return set(self._index.keys())
 
     @property
-    def taxids(self) -> set[int]:
-        """A list of Taxonomy IDs of snapshots."""
-        self._update_index()
-
-        return set(self.index_by_taxid.keys())
-
-    @property
     def accessions(self) -> set[str]:
         return set(self._get_accession_index().keys())
 
@@ -202,6 +194,7 @@ class Snapshotter:
             return self.load_by_id(otu_id)
 
         return None
+
     def _build_index(self) -> dict[UUID, OTUKeys]:
         """Build a new index from the contents of the snapshot cache directory"""
         index = {}

--- a/virtool_cli/ref/snapshot/index.py
+++ b/virtool_cli/ref/snapshot/index.py
@@ -133,11 +133,6 @@ class Snapshotter:
     def accessions(self) -> set[str]:
         return set(self._get_accession_index().keys())
 
-    def clean(self):
-        """Remove and remake snapshot cache directory"""
-        shutil.rmtree(self.path)
-        self.path.mkdir(exist_ok=True)
-
     def snapshot(
         self,
         otus: list[EventSourcedRepoOTU],


### PR DESCRIPTION
* Rename `SnapshotIndex` to `Snapshotter`. This keeps naming consistent.
* Remove unused repo properties.
* Remove unused `Snapshotter.clean` method.
* Rename `Snapshotter` load methods and test.
* Use `get_otu_by_taxid` in create_otu instead of index.
